### PR TITLE
Carthage fixes

### DIFF
--- a/SwiftMessages.xcodeproj/project.pbxproj
+++ b/SwiftMessages.xcodeproj/project.pbxproj
@@ -417,7 +417,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SwiftMessages/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = it.swiftkick.SwiftMessages;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -440,7 +439,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SwiftMessages/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = it.swiftkick.SwiftMessages;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -455,7 +453,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = SwiftMessagesTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = it.swiftkick.SwiftMessagesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -466,7 +463,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = SwiftMessagesTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = it.swiftkick.SwiftMessagesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SwiftMessages.xcodeproj/project.pbxproj
+++ b/SwiftMessages.xcodeproj/project.pbxproj
@@ -26,6 +26,10 @@
 		86BBA9061D5E040C00FE8F16 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864495551D4F7C390056EB2A /* Identifiable.swift */; };
 		86BBA9071D5E040C00FE8F16 /* MarginAdjustable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AAF81D1D5549680031EE32 /* MarginAdjustable.swift */; };
 		86BBA9081D5E040C00FE8F16 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AAF82A1D580DD70031EE32 /* Error.swift */; };
+		E6E49F911D70A344006CB883 /* MessageView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 862C0CDA1D5A397F00D06168 /* MessageView.xib */; };
+		E6E49F921D70A349006CB883 /* StatusLine.xib in Resources */ = {isa = PBXBuildFile; fileRef = 862C0CDB1D5A397F00D06168 /* StatusLine.xib */; };
+		E6E49F931D70A34C006CB883 /* MessageViewIOS8.xib in Resources */ = {isa = PBXBuildFile; fileRef = 862C0CE21D5A3A0D00D06168 /* MessageViewIOS8.xib */; };
+		E6E49F941D70A395006CB883 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 862C0CD91D5A397F00D06168 /* Images.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -268,8 +272,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6E49F931D70A34C006CB883 /* MessageViewIOS8.xib in Resources */,
+				E6E49F911D70A344006CB883 /* MessageView.xib in Resources */,
 				86BBA8F91D5E01FC00FE8F16 /* CardView.xib in Resources */,
+				E6E49F941D70A395006CB883 /* Images.xcassets in Resources */,
 				86589D911D692B1C0041676C /* TabView.xib in Resources */,
+				E6E49F921D70A349006CB883 /* StatusLine.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftMessages/NSBundle+Utils.swift
+++ b/SwiftMessages/NSBundle+Utils.swift
@@ -10,7 +10,12 @@ import Foundation
 
 extension NSBundle {
     static func sm_frameworkBundle() -> NSBundle {
-        let path = NSBundle(forClass: MessageView.self).pathForResource("SwiftMessages", ofType: "bundle")!
-        return NSBundle(path: path)!
+        let bundle = NSBundle(forClass: MessageView.self)
+        if let path = bundle.pathForResource("SwiftMessages", ofType: "bundle") {
+            return NSBundle(path: path)!
+        }
+        else {
+            return bundle
+        }
     }
 }


### PR DESCRIPTION
Hi!

I tried to add SwiftMessages to an iOS 9.0 project using Carthage but, since the framework deployment target is set to 9.3, compilation was failing.

I therefore updated the deployment target to iOS 8.0 for the framework target, since the same compatibility is declared by the podspec. To check my fix was correct, I started with an empty iOS 8 project and added this iOS 8 compatible framework using Carthage. I then ran into two additional issues:

* When the framework is built natively with Carthage, resources are put in the framework directory directly, not in the additional `SwiftMessages.bundle` bundle which only gets generated when using CocoaPods. As a result, `sm_frameworkBundle ` was crashing. I fixed how the bundle is resolved by this method, so that both use cases now work
* Almost all xibs and images were missing in the framework target. I simply added them

All in all, integration in an iOS >= 8 project with Carthage now works like a charm.

Thank you very much for your SwiftMessages library. It seems really great!

Cheers.