### PR TITLE
Add `ProvisioningStyle: Automatic;` to framework target

### DIFF
--- a/SwiftMessages.xcodeproj/project.pbxproj
+++ b/SwiftMessages.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 					86B48AEB1D5A41C900063E2B = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					86B48AF41D5A41C900063E2B = {
 						CreatedOnToolsVersion = 7.3.1;


### PR DESCRIPTION
Provisioning style 'Automatic' is the most consumer friendly provisioning style for frameworks. It permits the host project to dictate the provisioning style. 
Otherwise if a host project specifies Manual provisioning style, xcodebuild will fail when attempting to compile the subproject with:

> SwiftMessages does not support provisioning profiles. SwiftMessages does not support provisioning profiles, but provisioning profile has been manually specified. Set the provisioning profile value to "Automatic" in the build settings editor.