### PR TITLE
Renamed Theme enum

### DIFF
--- a/SwiftMessages/MessageView.swift
+++ b/SwiftMessages/MessageView.swift
@@ -156,7 +156,7 @@ extension MessageView {
      - Parameter theme: The theme type to use.
      - Parameter iconStyle: The icon style to use. Defaults to `.Default`.
      */
-    public func configureTheme(_ theme: Theme, iconStyle: IconStyle = .default) {
+    public func configureTheme(_ theme: SMTheme, iconStyle: IconStyle = .default) {
         let iconImage = iconStyle.image(theme: theme)
         switch theme {
         case .info:

--- a/SwiftMessages/Theme.swift
+++ b/SwiftMessages/Theme.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The theme enum specifies the built-in theme options
-public enum Theme {
+public enum SMTheme {
     case info
     case success
     case warning
@@ -46,7 +46,7 @@ public enum IconStyle {
     case subtle
     
     /// Returns the image for the given theme
-    public func image(theme: Theme) -> UIImage {
+    public func image(theme: SMTheme) -> UIImage {
         switch (theme, self) {
         case (.info, .default): return Icon.Info.image
         case (.info, .light): return Icon.InfoLight.image


### PR DESCRIPTION
Renamed **Theme** enum in **SMTheme**, could result a duplication with other lib or app classes