### PR TITLE
Dispatched Presenter.init(config:view:delegate:) call in SwiftMessages class to the main queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [3.1.4](https://github.com/SwiftKickMobile/SwiftMessages/releases/tag/3.1.4)
+
+### Bug Fixes
+
+* Fixed an issue where UIKit components were being instantiated off the main queue.
+
 ## [3.1.3](https://github.com/SwiftKickMobile/SwiftMessages/releases/tag/3.1.3)
 
 ### Features

--- a/SwiftMessages.podspec
+++ b/SwiftMessages.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
     spec.name             = 'SwiftMessages'
-    spec.version          = '3.1.3'
+    spec.version          = '3.1.4'
     spec.license          = { :type => 'MIT' }
     spec.homepage         = 'https://github.com/SwiftKickMobile/SwiftMessages'
     spec.authors          = { 'Timothy Moose' => 'tim@swiftkick.it' }
     spec.summary          = 'A very flexible message bar for iOS written in Swift.'
-    spec.source           = {:git => 'https://github.com/SwiftKickMobile/SwiftMessages.git', :tag => '3.1.3'}
+    spec.source           = {:git => 'https://github.com/SwiftKickMobile/SwiftMessages.git', :tag => '3.1.4'}
     spec.platform         = :ios, '8.0'
     spec.ios.deployment_target = '8.0'
     spec.source_files     = 'SwiftMessages/**/*.swift'

--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -244,10 +244,13 @@ open class SwiftMessages: PresenterDelegate {
      - Parameter view: The view to be displayed.
      */
     open func show(config: Config, view: UIView) {
-        syncQueue.async { [weak self] in
+        DispatchQueue.main.async { [weak self] in
             guard let strongSelf = self else { return }
             let presenter = Presenter(config: config, view: view, delegate: strongSelf)
-            strongSelf.enqueue(presenter: presenter)
+            strongSelf.syncQueue.async { [weak self] in
+                guard let strongSelf = self else { return }
+                strongSelf.enqueue(presenter: presenter)
+            }
         }
     }
     


### PR DESCRIPTION
`Presenter.init(config:view:delegate:)` initializes a `PassthroughView` instance variable called `maskingView` which is a `UIView` and this triggers a `setNeedsDisplay` call that should be made in the main thread.