### PR TITLE
Prevents a loss of a message.

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -277,7 +277,10 @@ class Presenter: NSObject, UIGestureRecognizerDelegate {
         }
     }
 
+    var isHiding = false
+
     func hide(completion: @escaping (_ completed: Bool) -> Void) {
+        isHiding = true
         self.config.eventListeners.forEach { $0(.willHide) }
         switch config.presentationStyle {
         case .top, .bottom:
@@ -311,7 +314,7 @@ class Presenter: NSObject, UIGestureRecognizerDelegate {
 //                completion(completed: completed)
 //            })
         }
-        
+
         func undim() {
             UIView.animate(withDuration: 0.2, animations: {
                 self.maskingView.backgroundColor = UIColor.clear

--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -366,7 +366,7 @@ open class SwiftMessages: PresenterDelegate {
     
     func enqueue(presenter: Presenter) {
         if presenter.config.ignoreDuplicates, let id = presenter.id {
-            if current?.id == id { return }
+            if current?.id == id && current?.isHiding == false { return }
             if queue.filter({ $0.id == id }).count > 0 { return }
         }
         queue.append(presenter)


### PR DESCRIPTION
Before this change, if a message is shown while the message of the same type
is being dismissed, the second message will simply be discarded.

After this change, the second message will be properly queued.

Please let me know if this is something you would be willing to merge. Any feedback is welcome.

Thanks!