### PR TITLE
Make accessibility prefix public

### DIFF
--- a/Demo/Demo/ExploreViewController.swift
+++ b/Demo/Demo/ExploreViewController.swift
@@ -42,12 +42,16 @@ class ExploreViewController: UITableViewController, UITextFieldDelegate {
         switch theme.selectedSegmentIndex {
         case 0:
             view.configureTheme(.info, iconStyle: iconStyle)
+            view.accessibilityPrefix = "info"
         case 1:
             view.configureTheme(.success, iconStyle: iconStyle)
+            view.accessibilityPrefix = "success"
         case 2:
             view.configureTheme(.warning, iconStyle: iconStyle)
+            view.accessibilityPrefix = "warning"
         case 3:
             view.configureTheme(.error, iconStyle: iconStyle)
+            view.accessibilityPrefix = "error"
         default:
             let iconText = ["🐸", "🐷", "🐬", "🐠", "🐍", "🐹", "🐼"].sm_random()
             view.configureTheme(backgroundColor: UIColor.purple, foregroundColor: UIColor.white, iconImage: nil, iconText: iconText)

--- a/SwiftMessages/MessageView.swift
+++ b/SwiftMessages/MessageView.swift
@@ -92,7 +92,7 @@ open class MessageView: BaseView, Identifiable, AccessibleMessage {
      the view's background color or icon might convey that a message is
      a warning, in which case one may specify the value "warning".
      */
-    private var accessibilityPrefix: String?
+    open var accessibilityPrefix: String?
 
     open var accessibilityMessage: String? {
         let components = [accessibilityPrefix, titleLabel?.text, bodyLabel?.text].flatMap { $0 }


### PR DESCRIPTION
Hi!

According to the [readme](https://github.com/SwiftKickMobile/SwiftMessages/blob/144e745be6cb7b80500fd93ac817458470d53c6b/README.md#accessibility), a `MessageView.accessibilityPrefix` should be available to assign a hint about the type of message VoiceOver is about to read. This is an excellent idea.

Sadly, this property is currently private and cannot be set. I therefore made it open, as it probably should have been right from the start, and updated the demo accordingly.

Thank you very much in advance for your work and for reviewing this PR.

Best regards.