### PR TITLE
Fix Slow Pan not dismissing Bug

### DIFF
--- a/SwiftMessages/TopBottomAnimation.swift
+++ b/SwiftMessages/TopBottomAnimation.swift
@@ -21,7 +21,7 @@ public class TopBottomAnimation: NSObject, Animator {
 
     open var closeSpeedThreshold: CGFloat = 750.0;
 
-    open var closePercentThreshold: CGFloat = 33.0;
+    open var closePercentThreshold: CGFloat = 0.33;
 
     private(set) var translationConstraint: NSLayoutConstraint! = nil
 


### PR DESCRIPTION
`closePercent` is a value from 0-1, `closePercentThreshold` assumes a value range from 0-100.

This means that in a top-bottom message, slowly panning up above the threshold does not dismiss the banner. It is only ever dismissed if the speed is higher than the threshold.