### PR TITLE
Fixes #208

### DIFF
--- a/SwiftMessages/MarginAdjustable+Animation.swift
+++ b/SwiftMessages/MarginAdjustable+Animation.swift
@@ -33,7 +33,7 @@ public extension MarginAdjustable where Self: UIView {
                 top += safeAreaTopOffset
             } else if let app = application, app.statusBarOrientation == .portrait || app.statusBarOrientation == .portraitUpsideDown {
                 let frameInWindow = convert(bounds, to: window)
-                if frameInWindow.minY == 0 {
+                if frameInWindow.minY <= 0 {
                     top += statusBarOffset
                 }
             }


### PR DESCRIPTION
This will fix the offset calculations being wrong on iOS 10.x after rotation or when using control center if notification is displayed in a windowed context on normal ui level.

Fixes #208 