### PR TITLE
Removed delay after physics pan dismiss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 6.0.1
+
+### Features
+* #257 Add the ability to specify the hide delay on `PhysicsPanHandler`. When `PhysicsPanHandler`'s dismissal gesture determines that the view is out of the container view's bounds, it waits `hideDelay` seconds before calling `SwiftMessages.hide()`. The default value is 0.2, which is what you'll get when using `presentationStyle = .center`. To specify a different delay, use `presentationStyle = .custom(animator:)` and supply an instance of `PhysicsPanHandler` configured to your liking.
+
 ## 6.0.0
 
 ### Changes

--- a/SwiftMessages.podspec
+++ b/SwiftMessages.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name             = 'SwiftMessages'
-    spec.version          = '6.0.0'
+    spec.version          = '6.0.1'
     spec.license          = { :type => 'MIT' }
     spec.homepage         = 'https://github.com/SwiftKickMobile/SwiftMessages'
     spec.authors          = { 'Timothy Moose' => 'tim@swiftkick.it' }

--- a/SwiftMessages/PhysicsPanHandler.swift
+++ b/SwiftMessages/PhysicsPanHandler.swift
@@ -119,7 +119,7 @@ open class PhysicsPanHandler {
                 let frame = containerView.convert(view.bounds, from: view)
                 if !containerView.bounds.intersects(frame) {
                     strongSelf.isOffScreen = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                    DispatchQueue.main.async {
                         animator.delegate?.hide(animator: animator)
                     }
                 }

--- a/SwiftMessages/PhysicsPanHandler.swift
+++ b/SwiftMessages/PhysicsPanHandler.swift
@@ -10,6 +10,10 @@ import UIKit
 
 open class PhysicsPanHandler {
 
+    /// During the dismiss gesture, specifies the delay between the view
+    /// going out of the screen's bounds and `SwiftMessages.hide()` being called.
+    public var hideDelay: TimeInterval = 0.2
+
     public struct MotionSnapshot {
         var angle: CGFloat
         var time: CFAbsoluteTime
@@ -114,12 +118,12 @@ open class PhysicsPanHandler {
             let attachmentBehavior = UIAttachmentBehavior(item: messageView, offsetFromCenter: offset, attachedToAnchor: anchorPoint)
             state.attachmentBehavior = attachmentBehavior
             state.itemBehavior.action = { [weak self, weak messageView, weak containerView] in
-                guard let strongSelf = self, !strongSelf.isOffScreen, let messageView = messageView, let containerView = containerView, let animator = strongSelf.animator else { return }
+                guard let self = self, !self.isOffScreen, let messageView = messageView, let containerView = containerView, let animator = self.animator else { return }
                 let view = (messageView as? BackgroundViewable)?.backgroundView ?? messageView
                 let frame = containerView.convert(view.bounds, from: view)
                 if !containerView.bounds.intersects(frame) {
-                    strongSelf.isOffScreen = true
-                    DispatchQueue.main.async {
+                    self.isOffScreen = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + self.hideDelay) {
                         animator.delegate?.hide(animator: animator)
                     }
                 }


### PR DESCRIPTION
# Context
I am using SwiftMessages to present overlay view controllers with interactive dismiss-/pan-animations.

# Issue
One of my designers noticed a short delay, after the presented view controller was dismissed and the overlay dim view fades out. He asked me to remove it as it was interrupting the user flow, as it feels longer than the given 0.35 seconds.

## Steps to reproduce
Simply display a view controller using the `SwiftMessagesSegue` and swipe it slowly out of the view so it disappears. You should notice a short delay until the black-dim-overlay disappears and the underlying view is accessible again.

```swift
let baseVC: UIViewController = ...
let detailVC: UIViewController = ...

let segue = SwiftMessagesSegue(identifier: nil, source: baseVC, destination: detailVC)
segue.configure(layout: .centered)
segue.messageView.layoutMarginAdditions = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
segue.messageView.configureDropShadow()

segue.dimMode = .gray(interactive: true)
segue.interactiveHide = true

segue.perform()
```

# Resolution
To speed up the dismiss animation to be similar to the simple tap-dismiss, I removed the async delay.

# Notes/Questions
Is there a specific reason this delay has been added?
Is there a different approach in fixing this behaviour? 