### PR TITLE
Fix: Unexpected version number in 'available' attribute for non-specific platform '*'

### DIFF
--- a/SwiftMessages/BaseView.swift
+++ b/SwiftMessages/BaseView.swift
@@ -256,7 +256,7 @@ open class BaseView: UIView, BackgroundViewable, MarginAdjustable {
      Note that this height is not guaranteed depending on anyt Auto Layout
      constraints used within the message view.
      */
-    @available(*, deprecated:4.2.0, message:"Use `backgroundHeight` instead to specify preferred height of the visible region of the message.")
+    @available(*, deprecated, message:"Use `backgroundHeight` instead to specify preferred height of the visible region of the message.")
     open var preferredHeight: CGFloat? {
         didSet {
             setNeedsLayout()


### PR DESCRIPTION
Deprecation was added by 87938e45d00589f1e4096834056493f2ca05590d and squashed in #198. But the value "4.2.0" is incorrect, as the `deprecated` value is supposed to be an iOS version, not a Swift version.

<img width="909" alt="screen shot 2019-02-22 at 10 47 37" src="https://user-images.githubusercontent.com/839992/53216376-49ecf500-368f-11e9-8d64-567ea80b8de0.png">
