### PR TITLE
'public' modifier is redundant for instance method declared in a public extension

### DIFF
--- a/SwiftMessages/Array+Utils.swift
+++ b/SwiftMessages/Array+Utils.swift
@@ -14,7 +14,7 @@ public extension Array {
      Returns a random element from the array. Can be used to create a playful
      message that cycles randomly through a set of emoji icons, for example.
      */
-    public func sm_random() -> Iterator.Element? {
+    func sm_random() -> Iterator.Element? {
         guard count > 0 else { return nil }
         return self[Int(arc4random_uniform(UInt32(count)))]
     }

--- a/SwiftMessages/MarginAdjustable+Animation.swift
+++ b/SwiftMessages/MarginAdjustable+Animation.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public extension MarginAdjustable where Self: UIView {
 
-    public func defaultMarginAdjustment(context: AnimationContext) -> UIEdgeInsets {
+    func defaultMarginAdjustment(context: AnimationContext) -> UIEdgeInsets {
         // Best effort to determine if we should use the new or deprecated margin adjustments.
         if layoutMarginAdditions != .zero
             || (safeAreaTopOffset == 0 && safeAreaBottomOffset == 0 && statusBarOffset == 0) {


### PR DESCRIPTION
default Xcode warnings

<img width="947" alt="screen shot 2019-02-22 at 11 04 03" src="https://user-images.githubusercontent.com/839992/53217401-c92ff800-3692-11e9-8276-7678664bb631.png">
