### PR TITLE
Created new configuration for letting user set overlapping behaviour of message view when setting on window and top.

### DIFF
--- a/Demo/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Demo/Base.lproj/Main.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="JQZ-C5-7mw">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="JQZ-C5-7mw">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -435,12 +433,44 @@
                                             </variation>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="7lB-n8-0ss" userLabel="Auto rotate cell">
+                                        <rect key="frame" x="0.0" y="403.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7lB-n8-0ss" id="Uor-9j-uco">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SHOULD OVERLAP" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BrY-J7-pMI" userLabel="Should overlap">
+                                                    <rect key="frame" x="26" y="11" width="121.5" height="16"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AyJ-RL-G6n">
+                                                    <rect key="frame" x="300" y="3.5" width="51" height="31"/>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="AyJ-RL-G6n" secondAttribute="trailing" constant="10" id="DgL-53-SLi"/>
+                                                <constraint firstItem="BrY-J7-pMI" firstAttribute="centerY" secondItem="Uor-9j-uco" secondAttribute="centerY" id="Pxc-YR-ilt"/>
+                                                <constraint firstItem="BrY-J7-pMI" firstAttribute="leading" secondItem="Uor-9j-uco" secondAttribute="leadingMargin" constant="10" id="Sls-xs-m2p"/>
+                                                <constraint firstItem="BrY-J7-pMI" firstAttribute="top" secondItem="Uor-9j-uco" secondAttribute="topMargin" id="byk-QZ-Evu"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BrY-J7-pMI" secondAttribute="trailingMargin" id="fIi-9e-8pG"/>
+                                                <constraint firstItem="AyJ-RL-G6n" firstAttribute="centerY" secondItem="BrY-J7-pMI" secondAttribute="centerY" id="q89-8c-VEA"/>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="Pxc-YR-ilt"/>
+                                                </mask>
+                                            </variation>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Styling" id="Ibz-q6-0d2">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="65" id="u46-FS-ahC" userLabel="Theme cell">
-                                        <rect key="frame" x="0.0" y="459.5" width="375" height="65"/>
+                                        <rect key="frame" x="0.0" y="503.5" width="375" height="65"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="u46-FS-ahC" id="A01-Bb-OrK">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="65"/>
@@ -474,7 +504,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="65" id="v73-pR-Iy2" userLabel="Theme cell">
-                                        <rect key="frame" x="0.0" y="524.5" width="375" height="65"/>
+                                        <rect key="frame" x="0.0" y="568.5" width="375" height="65"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="v73-pR-Iy2" id="Fdp-gh-OCb">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="65"/>
@@ -509,10 +539,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="65" id="0mE-sA-4rN" userLabel="Theme cell">
-                                        <rect key="frame" x="0.0" y="589.5" width="375" height="65"/>
+                                        <rect key="frame" x="0.0" y="633.5" width="375" height="65"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0mE-sA-4rN" id="eVs-bm-01A">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="65"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ICON STYLE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sXY-rl-8uH">
@@ -542,7 +572,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="4RW-U9-BVB" userLabel="Drop shadow cell">
-                                        <rect key="frame" x="0.0" y="654.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="698.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="4RW-U9-BVB" id="wdb-hX-CIv">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -578,7 +608,7 @@
                             <tableViewSection headerTitle="CONTENT" id="Mih-L6-PeE">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="65" id="ddI-Jn-NgP" userLabel="Title cell">
-                                        <rect key="frame" x="0.0" y="754.5" width="375" height="65"/>
+                                        <rect key="frame" x="0.0" y="798.5" width="375" height="65"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ddI-Jn-NgP" id="4HG-zA-HtF">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
@@ -608,7 +638,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="65" id="bdE-R5-mtF" userLabel="Subtitle cell">
-                                        <rect key="frame" x="0.0" y="819.5" width="375" height="65"/>
+                                        <rect key="frame" x="0.0" y="863.5" width="375" height="65"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bdE-R5-mtF" id="E8h-YG-8UX">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
@@ -638,7 +668,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="110" id="i0m-Xn-tMe" userLabel="Hiding cell">
-                                        <rect key="frame" x="0.0" y="884.5" width="375" height="110"/>
+                                        <rect key="frame" x="0.0" y="928.5" width="375" height="110"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="i0m-Xn-tMe" id="y4L-XO-6WY">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="109.5"/>
@@ -808,6 +838,7 @@
                         <outlet property="layout" destination="aBT-5M-2tg" id="4GZ-iP-oCa"/>
                         <outlet property="presentationContext" destination="AYG-qj-yjv" id="oxG-AK-tTF"/>
                         <outlet property="presentationStyle" destination="Agu-Vo-ckI" id="OuZ-YZ-Ktx"/>
+                        <outlet property="shouldOverlap" destination="AyJ-RL-G6n" id="5KU-KT-aeO"/>
                         <outlet property="showBody" destination="zUi-zd-sZL" id="LJh-6j-NzE"/>
                         <outlet property="showButton" destination="w9C-j2-COD" id="Tjc-CK-8lA"/>
                         <outlet property="showIcon" destination="mfB-t8-O1h" id="Ff9-V1-yuO"/>

--- a/Demo/Demo/ExploreViewController.swift
+++ b/Demo/Demo/ExploreViewController.swift
@@ -85,7 +85,7 @@ class ExploreViewController: UITableViewController, UITextFieldDelegate {
         // Config setup
         
         var config = SwiftMessages.defaultConfig
-        
+        config.presentationStyle = .top(shouldOverlap: shouldOverlap.isOn)
         switch presentationStyle.selectedSegmentIndex {
         case 1:
             config.presentationStyle = .bottom
@@ -159,6 +159,7 @@ class ExploreViewController: UITableViewController, UITextFieldDelegate {
     @IBOutlet weak var iconStyle: UISegmentedControl!
     @IBOutlet weak var autoRotate: UISwitch!
     @IBOutlet weak var dropShadow: UISwitch!
+    @IBOutlet weak var shouldOverlap: UISwitch!
     @IBOutlet weak var titleText: UITextField!
     @IBOutlet weak var bodyText: UITextField!
     @IBOutlet weak var showButton: UISwitch!

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -102,7 +102,7 @@ class ViewController: UITableViewController {
         status2.bodyLabel?.textColor = UIColor.white
         status2.configureContent(body: "Switched to light status bar!")
         var status2Config = SwiftMessages.defaultConfig
-        status2Config.shouldNotOverlap = true
+        status2Config.presentationStyle = .top(shouldOverlap: false)
         status2Config.presentationContext = .window(windowLevel: UIWindow.Level.normal)
         status2Config.preferredStatusBarStyle = .lightContent
 

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -102,6 +102,7 @@ class ViewController: UITableViewController {
         status2.bodyLabel?.textColor = UIColor.white
         status2.configureContent(body: "Switched to light status bar!")
         var status2Config = SwiftMessages.defaultConfig
+        status2Config.shouldNotOverlap = true
         status2Config.presentationContext = .window(windowLevel: UIWindow.Level.normal)
         status2Config.preferredStatusBarStyle = .lightContent
 

--- a/SwiftMessages/Animator.swift
+++ b/SwiftMessages/Animator.swift
@@ -14,6 +14,8 @@ public protocol AnimationDelegate: class {
     func hide(animator: Animator)
     func panStarted(animator: Animator)
     func panEnded(animator: Animator)
+    func resetRootViewLayout()
+    func updateLayoutForRootView(animator: AnimationContext?)
 }
 
 /**
@@ -49,12 +51,14 @@ public class AnimationContext {
     public let containerView: UIView
     public let safeZoneConflicts: SafeZoneConflicts
     public let interactiveHide: Bool
-
-    init(messageView: UIView, containerView: UIView, safeZoneConflicts: SafeZoneConflicts, interactiveHide: Bool) {
+    public let presentationContext: SwiftMessages.PresentationContext
+    
+    init(messageView: UIView, containerView: UIView, safeZoneConflicts: SafeZoneConflicts, interactiveHide: Bool, presentationContext: SwiftMessages.PresentationContext) {
         self.messageView = messageView
         self.containerView = containerView
         self.safeZoneConflicts = safeZoneConflicts
         self.interactiveHide = interactiveHide
+        self.presentationContext = presentationContext
     }
 }
 

--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -60,8 +60,8 @@ class Presenter: NSObject {
 
     private static func animator(forPresentationStyle style: SwiftMessages.PresentationStyle, delegate: AnimationDelegate) -> Animator {
         switch style {
-        case .top:
-            return TopBottomAnimation(style: .top, delegate: delegate)
+        case .top(let shouldOverlap):
+            return TopBottomAnimation(style: .top(overlapping: shouldOverlap), delegate: delegate)
         case .bottom:
             return TopBottomAnimation(style: .bottom, delegate: delegate)
         case .center:
@@ -124,20 +124,6 @@ class Presenter: NSObject {
                 }
                 self.config.eventListeners.forEach { $0(.didShow) }
             }
-        }
-        
-        func updateLayoutForRootView() {
-            if case .top = config.presentationStyle, case .window = config.presentationContext {
-                if let topView = UIApplication.shared.keyWindow?.rootViewController?.view {
-                    let frame = topView.frame
-                    let viewHeight = view.frame.height + view.frame.origin.y
-                    topView.frame = CGRect(x: frame.origin.x, y: frame.origin.y + viewHeight, width: frame.width, height: frame.height - viewHeight)
-                    topView.layoutIfNeeded()
-                }
-            }
-        }
-        if config.shouldNotOverlap {
-            updateLayoutForRootView()
         }
     }
 
@@ -209,19 +195,6 @@ class Presenter: NSObject {
             action()
         }
         
-        func updateLayoutForRootView() {
-            if case .top = config.presentationStyle, case .window = config.presentationContext {
-                if let topView = UIApplication.shared.keyWindow?.rootViewController?.view {
-                    let frame = topView.frame
-                    let messageView = context.messageView
-                    let viewHeight = abs(messageView.frame.height) - abs(messageView.frame.origin.y) + messageView.frame.height
-                    
-                    topView.frame = CGRect(x: frame.origin.x, y: frame.origin.y - viewHeight, width: frame.width, height: frame.height + viewHeight)
-                    topView.layoutIfNeeded()
-                }
-            }
-        }
-        
         func undim() {
             UIView.animate(withDuration: 0.2, delay: 0, options: .beginFromCurrentState, animations: {
                 self.maskingView.backgroundColor = UIColor.clear
@@ -245,14 +218,10 @@ class Presenter: NSObject {
         case .blur:
             unblur()
         }
-        
-        if config.shouldNotOverlap {
-            updateLayoutForRootView()
-        }
     }
-
+    
     private func animationContext() -> AnimationContext {
-        return AnimationContext(messageView: view, containerView: maskingView, safeZoneConflicts: safeZoneConflicts(), interactiveHide: config.interactiveHide)
+        return AnimationContext(messageView: view, containerView: maskingView, safeZoneConflicts: safeZoneConflicts(), interactiveHide: config.interactiveHide, presentationContext: config.presentationContext)
     }
 
     private func safeZoneConflicts() -> SafeZoneConflicts {

--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -125,6 +125,20 @@ class Presenter: NSObject {
                 self.config.eventListeners.forEach { $0(.didShow) }
             }
         }
+        
+        func updateLayoutForRootView() {
+            if case .top = config.presentationStyle, case .window = config.presentationContext {
+                if let topView = UIApplication.shared.keyWindow?.rootViewController?.view {
+                    let frame = topView.frame
+                    let viewHeight = view.frame.height + view.frame.origin.y
+                    topView.frame = CGRect(x: frame.origin.x, y: frame.origin.y + viewHeight, width: frame.width, height: frame.height - viewHeight)
+                    topView.layoutIfNeeded()
+                }
+            }
+        }
+        if config.shouldNotOverlap {
+            updateLayoutForRootView()
+        }
     }
 
     private func showAnimation(completion: @escaping AnimationCompletion) {
@@ -194,7 +208,20 @@ class Presenter: NSObject {
         animator.hide(context: context) { (completed) in
             action()
         }
-
+        
+        func updateLayoutForRootView() {
+            if case .top = config.presentationStyle, case .window = config.presentationContext {
+                if let topView = UIApplication.shared.keyWindow?.rootViewController?.view {
+                    let frame = topView.frame
+                    let messageView = context.messageView
+                    let viewHeight = abs(messageView.frame.height) - abs(messageView.frame.origin.y) + messageView.frame.height
+                    
+                    topView.frame = CGRect(x: frame.origin.x, y: frame.origin.y - viewHeight, width: frame.width, height: frame.height + viewHeight)
+                    topView.layoutIfNeeded()
+                }
+            }
+        }
+        
         func undim() {
             UIView.animate(withDuration: 0.2, delay: 0, options: .beginFromCurrentState, animations: {
                 self.maskingView.backgroundColor = UIColor.clear
@@ -217,6 +244,10 @@ class Presenter: NSObject {
             undim()
         case .blur:
             unblur()
+        }
+        
+        if config.shouldNotOverlap {
+            updateLayoutForRootView()
         }
     }
 
@@ -329,6 +360,7 @@ class Presenter: NSObject {
         }
 
         func bottomLayoutConstraint(view: UIView, containerView: UIView, viewController: UIViewController?) -> NSLayoutConstraint {
+            
             if case .bottom = config.presentationStyle, let tab = viewController as? UITabBarController, tab.sm_isVisible(view: tab.tabBar) {
                 return NSLayoutConstraint(item: view, attribute: .bottom, relatedBy: .equal, toItem: tab.tabBar, attribute: .top, multiplier: 1.00, constant: 0.0)
             }

--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -227,6 +227,13 @@ open class SwiftMessages {
         public init() {}
         
         /**
+         Specifies whether to update the layout of overlapping view,
+         Works for the case if presentationStyle is Top and view is
+         added on Window.
+         */
+        public var shouldNotOverlap = false
+        
+        /**
          Specifies whether the message view is displayed at the top or bottom
          of the selected presentation container. The default is `.Top`.
          */

--- a/SwiftMessages/SwiftMessagesSegue.swift
+++ b/SwiftMessages/SwiftMessagesSegue.swift
@@ -204,7 +204,7 @@ extension SwiftMessagesSegue {
         case .topMessage:
             messageView.layoutMarginAdditions = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
             messageView.collapseLayoutMarginAdditions = false
-            let animation = TopBottomAnimation(style: .top)
+            let animation = TopBottomAnimation(style: .top(overlapping: true))
             animation.springDamping = 1
             presentationStyle = .custom(animator: animation)
         case .bottomMessage:
@@ -218,7 +218,7 @@ extension SwiftMessagesSegue {
             messageView.layoutMarginAdditions = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
             messageView.collapseLayoutMarginAdditions = true
             containerView.cornerRadius = 15
-            presentationStyle = .top
+            presentationStyle = .top(shouldOverlap: true)
         case .bottomCard:
             containment = .background
             messageView.layoutMarginAdditions = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
@@ -231,7 +231,7 @@ extension SwiftMessagesSegue {
             messageView.collapseLayoutMarginAdditions = true
             containerView.cornerRadius = 15
             containerView.roundsLeadingCorners = true
-            let animation = TopBottomAnimation(style: .top)
+            let animation = TopBottomAnimation(style: .top(overlapping: true))
             animation.springDamping = 1
             presentationStyle = .custom(animator: animation)
         case .bottomTab:

--- a/SwiftMessages/TopBottomAnimation.swift
+++ b/SwiftMessages/TopBottomAnimation.swift
@@ -11,7 +11,7 @@ import UIKit
 public class TopBottomAnimation: NSObject, Animator {
 
     public enum Style {
-        case top
+        case top(overlapping: Bool)
         case bottom
     }
 
@@ -58,8 +58,11 @@ public class TopBottomAnimation: NSObject, Animator {
         self.context = context
         UIView.animate(withDuration: hideDuration!, delay: 0, options: [.beginFromCurrentState, .curveEaseIn], animations: {
             switch self.style {
-            case .top:
+            case .top(let shouldOverlap):
                 view.transform = CGAffineTransform(translationX: 0, y: -view.frame.height)
+                if !shouldOverlap {
+                    self.delegate?.resetRootViewLayout()
+                }
             case .bottom:
                 view.transform = CGAffineTransform(translationX: 0, y: view.frame.maxY + view.frame.height)
             }
@@ -141,6 +144,13 @@ public class TopBottomAnimation: NSObject, Animator {
             layoutMargins.bottom += bounceOffset
         }
         adjustable.layoutMargins = layoutMargins
+        containerView?.layoutIfNeeded()
+        
+        if case .top(let shouldOverlap) = style {
+            if !shouldOverlap {
+                delegate?.updateLayoutForRootView(animator: context)
+            }
+        }
     }
 
     func showAnimation(completion: @escaping AnimationCompletion) {

--- a/SwiftMessages/UIViewController+Utils.swift
+++ b/SwiftMessages/UIViewController+Utils.swift
@@ -101,7 +101,7 @@ extension SwiftMessages.PresentationStyle {
     /// presentation context logic to work with safe area insets.
     var topBottomStyle: TopBottomAnimation.Style? {
         switch self {
-        case .top: return .top
+        case .top(let shouldOverlap): return .top(overlapping: shouldOverlap)
         case .bottom: return .bottom
         case .custom(let animator): return (animator as? TopBottomAnimation)?.style
         case .center: return nil


### PR DESCRIPTION
Previously when any message view is displayed on top position on uiwindow it basically overlaps the content under it, I have created a new variable in configuration letting user set the bool, so that if he wants to update the rootVC frames or not.
<img width="284" alt="53865038-e27c6100-400f-11e9-9fa7-085d850a6c6a" src="https://user-images.githubusercontent.com/29425629/54106700-cd7d4480-43f8-11e9-97cd-43387cbce5af.png">
<img width="284" alt="53865041-e314f780-400f-11e9-8518-1c8c742d424a" src="https://user-images.githubusercontent.com/29425629/54106701-ce15db00-43f8-11e9-868c-0055e5ee29a4.png">

 