### PR TITLE
.index is deprecated in favor of .firstIndex

### DIFF
--- a/SwiftMessages/MaskingView.swift
+++ b/SwiftMessages/MaskingView.swift
@@ -36,7 +36,7 @@ class MaskingView: PassthroughView {
 
     override func index(ofAccessibilityElement element: Any) -> Int {
         guard let object = element as? NSObject else { return 0 }
-        return accessibleElements.index(of: object) ?? 0
+        return accessibleElements.firstIndex(of: object) ?? 0
     }
 
     init() {


### PR DESCRIPTION
This change is compatible with Swift 4 and it solves a warning in Xcode 10.2.