### PR TITLE
Fix .indefinite incorrect duration calculation

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -87,7 +87,7 @@ class Presenter: NSObject {
         return duration
     }
 
-    var showDate: Date?
+    var showDate: CFTimeInterval?
 
     private var interactivelyHidden = false;
 
@@ -100,7 +100,7 @@ class Presenter: NSObject {
     var delayHide: TimeInterval? {
         if interactivelyHidden { return 0 }
         if case .indefinite(let opts) = config.duration, let showDate = showDate {
-            let timeIntervalShown = -showDate.timeIntervalSinceNow
+            let timeIntervalShown = CACurrentMediaTime() - showDate
             return max(0, opts.minimum - timeIntervalShown)
         }
         return nil

--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -540,7 +540,7 @@ open class SwiftMessages {
         // the dismiss gesture begins before we've queued the autohide
         // block on animation completion.
         self.autohideToken = current
-        current.showDate = Date()
+        current.showDate = CACurrentMediaTime()
         DispatchQueue.main.async { [weak self] in
             guard let strongSelf = self else { return }
             do {


### PR DESCRIPTION
Replacing the Wall Clock (`Date()`) with a Monotonic Clock (`CACurrentMediaTime()`) will prevent negative durations when there are leap seconds or timezone changes.

For reference, here are classic solutions for Monotonic (and reliable) time progression:
 - `mach_absolute_time()` from Darwin, but requires conversion to seconds with mach_timebase_info
 - `ProcessInfo.processInfo.systemUptime` from Foundation, open-source wrapper on mach_absolute_time() giving directly a number of seconds
 - `DispatchTime.now()` from Dispatch, open-source wrapper on mach_absolute_time() giving easily a number of seconds
 - `CACurrentMediaTime()` from QuartzCore, close-source wrapper giving directly a number of seconds, and what Apple uses for animations: https://www.google.com/search?q=CACurrentMediaTime+site%3Aopensource.apple.com

And here are classic solutions for Wall clocks (totally *unreliable*! for timing) which are affected by leap seconds, timezone changes, winter/summer hour changes, any manual user change on the system clock:
- `gettimeofday()` in POSIX standard
- `DispatchWallTime.now()` from Dispatch
- `CFAbsoluteTimeGetCurrent()` from CoreFoundation
- `Date()`/`NSDate()` from Foundation and any of its methods (including `timeIntervalSinceReferenceDate`)
