### PR TITLE
Add basic SwiftPM manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "SwiftMessages",
+    // platforms: [.iOS("9.0")],
+    products: [
+        .library(name: "SwiftMessages", targets: ["SwiftMessages"])
+    ],
+    targets: [
+        .target(
+            name: "SwiftMessages",
+            path: "SwiftMessages"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ Add the following line to your Cartfile:
 github "SwiftKickMobile/SwiftMessages"
 ````
 
+### Accio
+
+Add the following to your Package.swift:
+
+```swift
+.package(url: "https://github.com/SwiftKickMobile/SwiftMessages.git", .upToNextMajor(from: "6.0.2")),
+```
+
+Next, add `SwiftMessages` to your App targets dependencies like so:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "SwiftMessages",
+    ]
+),
+```
+
+Then run `accio update`.
+
 ### Manual
 
 1. Put SwiftMessages repo somewhere in your project directory.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/cocoapods/l/SwiftMessages.svg?style=flat)](http://cocoadocs.org/docsets/SwiftMessages)
 [![Platform](https://img.shields.io/cocoapods/p/SwiftMessages.svg?style=flat)](http://cocoadocs.org/docsets/SwiftMessages)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 
 <p align="center">
   <img src="./Design/swiftmessages.png" />


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.