### PR TITLE
Inserted a conditional check to support Xcode 10.3

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -406,12 +406,16 @@ class Presenter: NSObject {
 
         guard let containerView = presentationContext.viewValue() else { return }
         if let windowViewController = presentationContext.viewControllerValue() as? WindowViewController {
+            #if swift(>=5.1)
             if #available(iOS 13, *) {
                 let scene = UIApplication.shared.keyWindow?.windowScene
                 windowViewController.install(becomeKey: becomeKeyWindow, scene: scene)
             } else {
                 windowViewController.install(becomeKey: becomeKeyWindow)
             }
+            #else
+            windowViewController.install(becomeKey: becomeKeyWindow)
+            #endif
         }
         installMaskingView(containerView: containerView)
         installInteractive()

--- a/SwiftMessages/WindowViewController.swift
+++ b/SwiftMessages/WindowViewController.swift
@@ -40,6 +40,7 @@ open class WindowViewController: UIViewController
         }
     }
 
+    #if swift(>=5.1)
     @available(iOS 13, *)
     func install(becomeKey: Bool, scene: UIWindowScene?) {
         guard let window = window else { return }
@@ -50,6 +51,7 @@ open class WindowViewController: UIViewController
             window.isHidden = false
         }
     }
+    #endif
     
     func uninstall() {
         window?.isHidden = true


### PR DESCRIPTION
Xcode 10.3 complains that it doesn't know what a `windowScene` is.
I added a directive to check for Swift 5.1 (the version included in Xcode 11), so that I can still compile the latest version in Xcode 10.3.

Tested in the demo app with Xcode 10.3 and Xcode 11.