### PR TITLE
Present SwiftMessages on top VC when using automatic presentationContext

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -298,8 +298,12 @@ class Presenter: NSObject {
             #if SWIFTMESSAGES_APP_EXTENSIONS
             throw SwiftMessagesError.noRootViewController
             #else
-            if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
-                let viewController = rootViewController.sm_selectPresentationContextTopDown(config)
+            if var topController = UIApplication.shared.keyWindow?.rootViewController {
+                while let presentedViewController = topController.presentedViewController {
+                    topController = presentedViewController
+                }
+                
+                let viewController = topController.sm_selectPresentationContextTopDown(config)
                 return .viewController(Weak(value: viewController))
             } else {
                 throw SwiftMessagesError.noRootViewController


### PR DESCRIPTION
Changes to modals in iOS 13 caused  .automatic presentationContext to not display SwiftMessages on top of modals. This change will allow SwiftMessages to present on top of a modal, while still working correctly from a view controller's nav bar (using .automatic presentationContext).