### PR TITLE
XCode 11.4

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -39,7 +39,7 @@ class Presenter: NSObject {
     let view: UIView
 
     var delayShow: TimeInterval? {
-        if case .indefinite(let opts) = config.duration { return opts.delay }
+        if case .indefinite(let delay, _) = config.duration { return delay }
         return nil
     }
 
@@ -48,9 +48,9 @@ class Presenter: NSObject {
     /// Returns the required delay for hiding based on time shown
     var delayHide: TimeInterval? {
         if interactivelyHidden { return 0 }
-        if case .indefinite(let opts) = config.duration, let showDate = showDate {
+        if case .indefinite(_, let minimum) = config.duration, let showDate = showDate {
             let timeIntervalShown = CACurrentMediaTime() - showDate
-            return max(0, opts.minimum - timeIntervalShown)
+            return max(0, minimum - timeIntervalShown)
         }
         return nil
     }


### PR DESCRIPTION
fixed warning
```swift
Cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead
```