### PR TITLE
Add preliminary support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "SwiftMessages",
+    // platforms: [.iOS("9.0")],
+    products: [
+        .library(name: "SwiftMessages", targets: ["SwiftMessages"])
+    ],
+    targets: [
+        .target(
+            name: "SwiftMessages",
+            path: "SwiftMessages"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftMessages",
-    // platforms: [.iOS("9.0")],
+    platforms: [.iOS("9.0")],
     products: [
         .library(name: "SwiftMessages", targets: ["SwiftMessages"])
     ],

--- a/SwiftMessages/CALayer+Utils.swift
+++ b/SwiftMessages/CALayer+Utils.swift
@@ -6,8 +6,7 @@
 //  Copyright © 2018 SwiftKick Mobile. All rights reserved.
 //
 
-import CoreAnimation
-import CoreGraphics
+import QuartzCore
 
 extension CALayer {
     func findAnimation(forKeyPath keyPath: String) -> CABasicAnimation? {

--- a/SwiftMessages/CALayer+Utils.swift
+++ b/SwiftMessages/CALayer+Utils.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 SwiftKick Mobile. All rights reserved.
 //
 
+import CoreAnimation
 import CoreGraphics
 
 extension CALayer {


### PR DESCRIPTION
Since SPM came around, people wanted SwiftMessages to be compatible with SPM (https://github.com/SwiftKickMobile/SwiftMessages/issues/330, https://github.com/SwiftKickMobile/SwiftMessages/issues/362). Sadly, SPM currently has no support for resource bundling – however, with Swift 5.3, this will finally change.

This pull request accomplishes two things:
1. **Add preliminary support for SPM** until Swift 5.3 officially appears
2. Prepare SwiftMessages for upcoming Swift 5.3 SPM support by adding a `Package.swift` and fixing SPM build errors.

---
### How To Use SwiftMessages With SPM?

If you really want to include SwiftMessages via SPM and not via Carthage/CocoaPods, there is a simple way. Swift Package Manager can be used to include and build the Swift sources; then, the resources must manually be added to your main target – this works without any problems.

This solution is natural and has a similar feel to SPM as it *handles resource updating automatically*.
You can set it up in three steps:
1. Add SwiftMessages to your project via Swift Package Manager (https://github.com/knothed/SwiftMessages)
2. Here is a directory containing all SwiftMessages resources. Just drop it somewhere into your project. [SwiftMessages-Resources.zip](https://github.com/SwiftKickMobile/SwiftMessages/files/4781215/SwiftMessages-Resources.zip)
3. Now, just adapt the `destination` in below build script and add it as a build phase if you want resource auto-updating (i.e. when a new release of SwiftMessages changes some of the resources, they are also automatically updated in your project – no manual work for you!)
```
source="${BUILD_DIR}/../../SourcePackages/checkouts/SwiftMessages/SwiftMessages/Resources"
destination="${PROJECT_DIR}/Path_To_SwiftMessages_Resource_Folder"
rsync -r "${source}" "${destination}/"
```
Only change `Path_To_SwiftMessages_Resource_Folder`, the rest should stay as is.

Thats the closest we can get to SPM until Swift 5.3 is released. Again, **it does work**.
I think this is worth a consideration for everyone who wants to use SwiftMessages with SPM **now** and not wait until Swift 5.3.