### PR TITLE
Adding option to present modal over context

### DIFF
--- a/SwiftMessages/SwiftMessagesSegue.swift
+++ b/SwiftMessages/SwiftMessagesSegue.swift
@@ -147,9 +147,11 @@ open class SwiftMessagesSegue: UIStoryboardSegue {
     }
 
     /**
-     Display the view over another view controller’s content.
+     Normally, the destination view controller's `modalPresentationStyle` is changed
+     to `.custom` in the `perform()` function. Set this property to `false` to prevent it from
+     being overridden.
     */
-    public var presentOverCurrentContext: Bool = false
+    public var overrideModalPresentationStyle: Bool = true
 
     /**
      The view that is passed to `SwiftMessages.show(config:view:)` during presentation.
@@ -196,7 +198,9 @@ open class SwiftMessagesSegue: UIStoryboardSegue {
 
     override open func perform() {
         selfRetainer = self
-        destination.modalPresentationStyle = presentOverCurrentContext ? .overCurrentContext : .custom
+        if overrideModalPresentationStyle {
+            destination.modalPresentationStyle = .custom
+        }
         destination.transitioningDelegate = self
         source.present(destination, animated: true, completion: nil)
     }

--- a/SwiftMessages/SwiftMessagesSegue.swift
+++ b/SwiftMessages/SwiftMessagesSegue.swift
@@ -147,6 +147,11 @@ open class SwiftMessagesSegue: UIStoryboardSegue {
     }
 
     /**
+     Display the view over another view controller’s content.
+    */
+    public var presentOverCurrentContext: Bool = false
+
+    /**
      The view that is passed to `SwiftMessages.show(config:view:)` during presentation.
      The view controller's view is installed into `containerView`, which is itself installed
      into `messageView`. `SwiftMessagesSegue` does this installation automatically based on the
@@ -191,7 +196,7 @@ open class SwiftMessagesSegue: UIStoryboardSegue {
 
     override open func perform() {
         selfRetainer = self
-        destination.modalPresentationStyle = .custom
+        destination.modalPresentationStyle = presentOverCurrentContext ? .overCurrentContext : .custom
         destination.transitioningDelegate = self
         source.present(destination, animated: true, completion: nil)
     }


### PR DESCRIPTION
I have a use case where I need to present a modal over a dedicated controller on iPad (kinda like a split view controller homemade). So, I searched If there was an option to do this but didn't find any, so here it is.

I think it's the right way to do this, but I don't know if it's there right way in `SwiftMessages`, let me know if any changes is needed.