### PR TITLE
Support applications which is using UIWindowSceneDelegate.

### DIFF
--- a/SwiftMessages/WindowViewController.swift
+++ b/SwiftMessages/WindowViewController.swift
@@ -34,6 +34,12 @@ open class WindowViewController: UIViewController
         }
     }
     
+    @available(iOS 13.0, *)
+    public convenience init(windowLevel: UIWindow.Level?, config: SwiftMessages.Config, windowScense: UIWindowScene) {
+        self.init(windowLevel: windowLevel, config: config)
+        window?.windowScene = windowScense
+    }
+    
     func install(becomeKey: Bool) {
         show(becomeKey: becomeKey)
     }


### PR DESCRIPTION
Set the windowViewController closure when you are using a UIWindowSceneDelegate based application.
for example:
```
var config = SwiftMessages.Config()
config.windowViewController = { windowLevel, config in
    // Get my first and only window scense. 
    if let windowScense = UIApplication.shared.connectedScenes.first as? UIWindowScene {
        return WindowViewController(windowLevel: windowLevel, config: config, windowScense: windowScense)
    } else {
        return WindowViewController(windowLevel: windowLevel, config: config)
    }
}
```