### PR TITLE
Support disable `becomeKeyWindow` from SwiftMessages.Config

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -434,7 +434,7 @@ class Presenter: NSObject {
     }
 
     private var becomeKeyWindow: Bool {
-        if config.becomeKeyWindow == .some(true) { return true }
+        if let becomeKeyWindow = config.becomeKeyWindow { return becomeKeyWindow }
         switch config.dimMode {
         case .gray, .color, .blur:
             // Should become key window in modal presentation style

--- a/SwiftMessages/WindowViewController.swift
+++ b/SwiftMessages/WindowViewController.swift
@@ -55,6 +55,9 @@ open class WindowViewController: UIViewController
     }
     
     func uninstall() {
+        if #available(iOS 13, *) {
+            window?.windowScene = nil
+        }
         window?.isHidden = true
         window = nil
     }


### PR DESCRIPTION
### Description
- Support disable `becomeKeyWindow` from SwiftMessages.Config
- Fix the problem clipboard (copy/paste) options is not displaying in TextField/Webview when using custom `dimMode`.
### Issue:
https://github.com/SwiftKickMobile/SwiftMessages/issues/429
### Screenshot
![clipboard](https://user-images.githubusercontent.com/7752679/97255133-87315f00-1842-11eb-8148-bff960611557.gif)
