### PR TITLE
Revert remove `windowScence` when hiding Toast view

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -434,7 +434,7 @@ class Presenter: NSObject {
     }
 
     private var becomeKeyWindow: Bool {
-        if config.becomeKeyWindow == .some(true) { return true }
+        if let becomeKeyWindow = config.becomeKeyWindow { return becomeKeyWindow }
         switch config.dimMode {
         case .gray, .color, .blur:
             // Should become key window in modal presentation style

--- a/SwiftMessages/WindowViewController.swift
+++ b/SwiftMessages/WindowViewController.swift
@@ -55,6 +55,9 @@ open class WindowViewController: UIViewController
     }
     
     func uninstall() {
+        if #available(iOS 13, *) {
+            window?.windowScene = nil
+        }
         window?.isHidden = true
         window = nil
     }

--- a/SwiftMessages/WindowViewController.swift
+++ b/SwiftMessages/WindowViewController.swift
@@ -55,9 +55,6 @@ open class WindowViewController: UIViewController
     }
     
     func uninstall() {
-        if #available(iOS 13, *) {
-            window?.windowScene = nil
-        }
         window?.isHidden = true
         window = nil
     }


### PR DESCRIPTION
### Description
- We have an issue that Popup can not show in the second time if the previous popup's window was `becomeActive`.
### Solutions
1. Just revert the logic clear the windowScene `window?.windowScene = nil`.
2. Add more condition check, if the current window `isKeyWindow` --> ignore.
```
if #available(iOS 13, *), window?.isKeyWindow == false {
            window?.windowScene = nil
}
```
### Isssue:
https://github.com/SwiftKickMobile/SwiftMessages/issues/429