### PR TITLE
FIX AppExtension target

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -102,7 +102,12 @@ class Presenter: NSObject {
     private var windowScene: UIWindowScene? {
         switch config.presentationContext {
         case .windowScene(let scene, _): return scene
-        default: return UIApplication.shared.keyWindow?.windowScene
+        default:
+            #if SWIFTMESSAGES_APP_EXTENSIONS
+            return nil
+            #else
+            return UIApplication.shared.keyWindow?.windowScene
+            #endif
         }
     }
 


### PR DESCRIPTION
With the introduction of support for window scenes the `AppExtension` target got [broken](https://github.com/SwiftKickMobile/SwiftMessages/commit/72851b9ad9e7ab6cd03d5d3568f70a01b3c0167b#r44767106).

This fixes access to `UIApplication.shared` by wrapping it into `SWIFTMESSAGES_APP_EXTENSIONS` as seen elsewhere in this code base.