### PR TITLE
Ignoring the SafeArea for margins is now possible.

### DIFF
--- a/SwiftMessages/BaseView.swift
+++ b/SwiftMessages/BaseView.swift
@@ -210,6 +210,9 @@ open class BaseView: UIView, BackgroundViewable, MarginAdjustable {
         }
     }
 
+    /// Start margins from the safe area.
+    open var respectSafeArea: Bool = true
+
     /// IBInspectable access to layoutMarginAdditions.top
     @IBInspectable open var topLayoutMarginAddition: CGFloat = 0
 

--- a/SwiftMessages/MarginAdjustable+Animation.swift
+++ b/SwiftMessages/MarginAdjustable+Animation.swift
@@ -11,26 +11,28 @@ import UIKit
 extension MarginAdjustable where Self: UIView {
     public func defaultMarginAdjustment(context: AnimationContext) -> UIEdgeInsets {
         var layoutMargins: UIEdgeInsets = layoutMarginAdditions
-        var safeAreaInsets: UIEdgeInsets
-        if #available(iOS 11, *) {
-            insetsLayoutMarginsFromSafeArea = false
-            safeAreaInsets = self.safeAreaInsets
-        } else {
-            #if SWIFTMESSAGES_APP_EXTENSIONS
-            let application: UIApplication? = nil
-            #else
-            let application: UIApplication? = UIApplication.shared
-            #endif
-            if !context.safeZoneConflicts.isDisjoint(with: [.statusBar]),
-                let app = application,
-                app.statusBarOrientation == .portrait || app.statusBarOrientation == .portraitUpsideDown {
-                let frameInWindow = convert(bounds, to: window)
-                let top = max(0, 20 - frameInWindow.minY)
-                safeAreaInsets = UIEdgeInsets(top: top, left: 0, bottom: 0, right: 0)
+        var safeAreaInsets: UIEdgeInsets = {
+            guard respectSafeArea else { return .zero }
+            if #available(iOS 11, *) {
+                insetsLayoutMarginsFromSafeArea = false
+                return self.safeAreaInsets
             } else {
-                safeAreaInsets = .zero
+                #if SWIFTMESSAGES_APP_EXTENSIONS
+                let application: UIApplication? = nil
+                #else
+                let application: UIApplication? = UIApplication.shared
+                #endif
+                if !context.safeZoneConflicts.isDisjoint(with: [.statusBar]),
+                   let app = application,
+                   app.statusBarOrientation == .portrait || app.statusBarOrientation == .portraitUpsideDown {
+                    let frameInWindow = convert(bounds, to: window)
+                    let top = max(0, 20 - frameInWindow.minY)
+                    return UIEdgeInsets(top: top, left: 0, bottom: 0, right: 0)
+                } else {
+                    return .zero
+                }
             }
-        }
+        }()
         if !context.safeZoneConflicts.isDisjoint(with: .overStatusBar) {
             safeAreaInsets.top = 0
         }

--- a/SwiftMessages/MarginAdjustable.swift
+++ b/SwiftMessages/MarginAdjustable.swift
@@ -33,6 +33,10 @@ public protocol MarginAdjustable {
     /// the additional margin is not added.
     var collapseLayoutMarginAdditions: Bool { get set }
 
+
+    /// Start margins from the safe area.
+    var respectSafeArea: Bool { get set }
+
     var bounceAnimationOffset: CGFloat { get set }
 }
 


### PR DESCRIPTION
This is the need for [issue #439: SwiftMessagesSegue Card style ignoring safe area ](https://github.com/SwiftKickMobile/SwiftMessages/issues/439)