### PR TITLE
FIX AppExtension target

### DIFF
--- a/SwiftMessages/WindowViewController.swift
+++ b/SwiftMessages/WindowViewController.swift
@@ -37,7 +37,9 @@ open class WindowViewController: UIViewController
     func install(becomeKey: Bool, scene: UIWindowScene?) {
         window?.windowScene = scene
         if becomeKey {
+            #if !SWIFTMESSAGES_APP_EXTENSIONS
             previousKeyWindow = UIApplication.shared.keyWindow
+            #endif
         }
         show(becomeKey: becomeKey, frame: scene?.coordinateSpace.bounds)
     }


### PR DESCRIPTION
This is a naive fix for compiling `SwiftMessages/AppExtension` target which broke with 
243fa75

It should be considered as a hotfix on top of 8.0.5. The same issue exists in 9.0 on current master.