### PR TITLE
Remove redundant words for `button` in `MessageView`.

### DIFF
--- a/SwiftMessages/MessageView.swift
+++ b/SwiftMessages/MessageView.swift
@@ -55,7 +55,7 @@ open class MessageView: BaseView, Identifiable, AccessibleMessage {
     
     /// An optional button. This buttons' `.TouchUpInside` event will automatically
     /// invoke the optional `buttonTapHandler`, but its fine to add other target
-    /// action handlers can be added.
+    /// action handlers.
     @IBOutlet open var button: UIButton? {
         didSet {
             if let old = oldValue {


### PR DESCRIPTION
## Description

I just removed the unnecessary words from the `button`'s standard code documentation. (`///` or `/** */`)