### PR TITLE
Use AnyObject instead of class for restricting the protocol to classes

### DIFF
--- a/SwiftMessages/Animator.swift
+++ b/SwiftMessages/Animator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public typealias AnimationCompletion = (_ completed: Bool) -> Void
 
-public protocol AnimationDelegate: class {
+public protocol AnimationDelegate: AnyObject {
     func hide(animator: Animator)
     func panStarted(animator: Animator)
     func panEnded(animator: Animator)
@@ -58,7 +58,7 @@ public class AnimationContext {
     }
 }
 
-public protocol Animator: class {
+public protocol Animator: AnyObject {
 
     /// Adopting classes should declare as `weak`.
     var delegate: AnimationDelegate? { get set }

--- a/SwiftMessages/KeyboardTrackingView.swift
+++ b/SwiftMessages/KeyboardTrackingView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol KeyboardTrackingViewDelegate: class {
+public protocol KeyboardTrackingViewDelegate: AnyObject {
     func keyboardTrackingViewWillChange(change: KeyboardTrackingView.Change, userInfo: [AnyHashable : Any])
     func keyboardTrackingViewDidChange(change: KeyboardTrackingView.Change, userInfo: [AnyHashable : Any])
 }


### PR DESCRIPTION
Xcode 12.5 started to show a warning about using `class` instead of recommended `AnyObject`.

<img width="550" alt="xcode-12-5-warning" src="https://user-images.githubusercontent.com/1469907/117747543-54ccd980-b249-11eb-9f26-10a717c1e2a1.png">


