### PR TITLE
fix: Fixed few warnings from Xcode 13 beta 1

### DIFF
--- a/SwiftMessages/Animator.swift
+++ b/SwiftMessages/Animator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public typealias AnimationCompletion = (_ completed: Bool) -> Void
 
-public protocol AnimationDelegate: class {
+public protocol AnimationDelegate: AnyObject {
     func hide(animator: Animator)
     func panStarted(animator: Animator)
     func panEnded(animator: Animator)
@@ -58,7 +58,7 @@ public class AnimationContext {
     }
 }
 
-public protocol Animator: class {
+public protocol Animator: AnyObject {
 
     /// Adopting classes should declare as `weak`.
     var delegate: AnimationDelegate? { get set }

--- a/SwiftMessages/KeyboardTrackingView.swift
+++ b/SwiftMessages/KeyboardTrackingView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol KeyboardTrackingViewDelegate: class {
+public protocol KeyboardTrackingViewDelegate: AnyObject {
     func keyboardTrackingViewWillChange(change: KeyboardTrackingView.Change, userInfo: [AnyHashable : Any])
     func keyboardTrackingViewDidChange(change: KeyboardTrackingView.Change, userInfo: [AnyHashable : Any])
 }

--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -93,16 +93,16 @@ class Presenter: NSObject {
     private var interactivelyHidden = false;
 
     var delayShow: TimeInterval? {
-        if case .indefinite(let opts) = config.duration { return opts.delay }
+        if case .indefinite(let delay, _) = config.duration { return delay }
         return nil
     }
 
     /// Returns the required delay for hiding based on time shown
     var delayHide: TimeInterval? {
         if interactivelyHidden { return 0 }
-        if case .indefinite(let opts) = config.duration, let showDate = showDate {
+        if case .indefinite(_, let minimum) = config.duration, let showDate = showDate {
             let timeIntervalShown = CACurrentMediaTime() - showDate
-            return max(0, opts.minimum - timeIntervalShown)
+            return max(0, minimum - timeIntervalShown)
         }
         return nil
     }


### PR DESCRIPTION
- Fixed 3 warnings about the now deprecated `class` constraint
- Fixed 2 warnings about pattern matching two values of an enum case as a tuple.

These appear as warnings when opening the project in Xcode 13 beta 1.