### PR TITLE
Add option to preserve status bar space

### DIFF
--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -299,6 +299,14 @@ open class SwiftMessages {
         public var prefersStatusBarHidden: Bool?
 
         /**
+         Specifies whether or not the space used by the status bar should be preserved
+         after hiding the status bar for devices without a notch. This can be useful in
+         combination with `prefersStatusBarHidden` to show the view on the space
+         used by the status bar. The default is `false`
+         */
+        public var preserveStatusBarSpace: Bool = false
+
+        /**
          If a view controller is created to host the message view, should the view 
          controller auto rotate?  The default is 'true', meaning it should auto
          rotate.

--- a/SwiftMessages/WindowViewController.swift
+++ b/SwiftMessages/WindowViewController.swift
@@ -49,6 +49,15 @@ open class WindowViewController: UIViewController
 
     private func show(becomeKey: Bool, frame: CGRect? = nil) {
         guard let window = window else { return }
+        if #available(iOS 13.0, *),
+           config.preserveStatusBarSpace,
+           let previousKeyWindowSafeAreaInsets = previousKeyWindow?.safeAreaInsets,
+           window.safeAreaInsets.top != previousKeyWindowSafeAreaInsets.top
+        {
+            initialAdditionalSafeAreaInsets = previousKeyWindow?.rootViewController?.additionalSafeAreaInsets
+            previousKeyWindow?.rootViewController?.additionalSafeAreaInsets.top += previousKeyWindowSafeAreaInsets.top
+        }
+
         window.frame = frame ?? UIScreen.main.bounds
         if becomeKey {
             window.makeKeyAndVisible()
@@ -63,6 +72,9 @@ open class WindowViewController: UIViewController
         }
         if #available(iOS 13, *) {
             window?.windowScene = nil
+            if let initialAdditionalSafeAreaInsets = initialAdditionalSafeAreaInsets {
+                previousKeyWindow?.rootViewController?.additionalSafeAreaInsets = initialAdditionalSafeAreaInsets
+            }
         }
         window?.isHidden = true
         window = nil
@@ -84,6 +96,7 @@ open class WindowViewController: UIViewController
 
     private var window: UIWindow?
     private weak var previousKeyWindow: UIWindow?
+    private var initialAdditionalSafeAreaInsets: UIEdgeInsets?
 
     let config: SwiftMessages.Config
 }


### PR DESCRIPTION
Since iOS 13 it is no longer possible to show a view over the status bar. The workaround for this is to hide the status bar before showing the view (see https://github.com/SwiftKickMobile/SwiftMessages/issues/335).

The issue with this, is that when hiding the status bar on a device without a notch, the window safe area is updated to reflect this, and the content of the app is moved up.

This PR aims to solve this by adding a new option, `Config.preserveStatusBarSpace`, that when set to `true` takes the previous window `safeAreaInsets` and applies it to the root view controller before showing the new window, and sets it back when removing the window.

I decide to set it to `false` by default to preserve the existing behavior. Let me know if you see any big implications of adding this change that I may have overlooked.