### PR TITLE
Fixed issue happening in iPad mini (6 gen) where a non-modal message …

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -363,7 +363,13 @@ class Presenter: NSObject {
         }
 
         func installInteractive() {
-            guard config.dimMode.modal else { return }
+            guard config.dimMode.modal
+            else {
+                maskingView.backgroundView?.isUserInteractionEnabled = false
+                return
+            }
+            
+            maskingView.backgroundView?.isUserInteractionEnabled = true
             if config.dimMode.interactive {
                 maskingView.tappedHander = { [weak self] in
                     guard let strongSelf = self else { return }


### PR DESCRIPTION
Fixed issue happening in iPad mini (6th generation) where a non-modal message would block interaction with underlying view.