### PR TITLE
Prevent orphaned views from blocking the queue

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -68,6 +68,13 @@ class Presenter: NSObject {
         return duration
     }
 
+    /// Detects the scenario where the view was shown, but the containing view heirarchy was removed before the view
+    /// was hidden. This unusual scenario could result in the message queue being blocked because the presented
+    /// view was not properly hidden by SwiftMessages. `isOrphaned` allows the queuing logic to unblock the queue.
+    var isOrphaned: Bool {
+        return installed && view.window == nil
+    }
+
     // MARK: - Constants
 
     enum PresentationContext {
@@ -97,7 +104,7 @@ class Presenter: NSObject {
 
     private weak var delegate: PresenterDelegate?
     private var presentationContext = PresentationContext.viewController(Weak<UIViewController>(value: nil))
-
+    private var installed = false
     private var interactivelyHidden = false;
 
     // MARK: - Showing and hiding
@@ -412,6 +419,7 @@ class Presenter: NSObject {
             maskingView.accessibleElements = elements
         }
 
+        installed = true
         guard let containerView = presentationContext.viewValue() else { return }
         (presentationContext.viewControllerValue() as? WindowViewController)?.install()
         installMaskingView(containerView: containerView)

--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -586,7 +586,10 @@ open class SwiftMessages {
     fileprivate func enqueue(presenter: Presenter) {
         if presenter.config.ignoreDuplicates {
             counts[presenter.id] = (counts[presenter.id] ?? 0) + 1
-            if _current?.id == presenter.id && _current?.isHiding == false { return }
+            if let _current,
+                _current.id == presenter.id,
+               !_current.isHiding,
+               !_current.isOrphaned { return }
             if queue.filter({ $0.id == presenter.id }).count > 0 { return }
         }
         func doEnqueue() {
@@ -606,7 +609,8 @@ open class SwiftMessages {
     }
     
     fileprivate func dequeueNext() {
-        guard self._current == nil, queue.count > 0 else { return }
+        guard queue.count > 0 else { return }
+        if let _current, !_current.isOrphaned { return }
         let current = queue.removeFirst()
         self._current = current
         // Set `autohideToken` before the animation starts in case


### PR DESCRIPTION
Potential fix for #516. Orphaned message views can block the queue. This PR attempts to prevent that from happening.