### PR TITLE
Relocate MainActor from class declaration

### DIFF
--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -16,7 +16,6 @@ private let globalInstance = SwiftMessages()
  It behaves like a queue, only showing one message at a time. Message views that
  adopt the `Identifiable` protocol (as `MessageView` does) will have duplicates removed.
  */
-@MainActor
 open class SwiftMessages {
     
     /**
@@ -408,6 +407,7 @@ open class SwiftMessages {
      - Parameter config: The configuration options.
      - Parameter view: The view to be displayed.
      */
+    @MainActor
     open func show(config: Config, view: UIView) {
         let presenter = Presenter(config: config, view: view, delegate: self)
         enqueue(presenter: presenter)
@@ -420,6 +420,7 @@ open class SwiftMessages {
      - Parameter config: The configuration options.
      - Parameter view: The view to be displayed.
      */
+    @MainActor
     public func show(view: UIView) {
         show(config: defaultConfig, view: view)
     }
@@ -462,6 +463,7 @@ open class SwiftMessages {
     /**
      Hide the current message being displayed by animating it away.
      */
+    @MainActor
     open func hide(animated: Bool = true) {
         hideCurrent(animated: animated)
     }
@@ -470,6 +472,7 @@ open class SwiftMessages {
      Hide the current message, if there is one, by animating it away and
      clear the message queue.
      */
+    @MainActor
     open func hideAll() {
         queue.removeAll()
         delays.removeAll()
@@ -483,6 +486,7 @@ open class SwiftMessages {
      views, such as `MessageView`, that adopt the `Identifiable` protocol.
      - Parameter id: The identifier of the message to remove.
      */
+    @MainActor
     open func hide(id: String) {
         if id == _current?.id {
             hideCurrent()
@@ -497,6 +501,7 @@ open class SwiftMessages {
      given message ID are equal. This can be useful for messages that may be
      shown from  multiple code paths to ensure that all paths are ready to hide.
      */
+    @MainActor
     open func hideCounted(id: String) {
         if let count = counts[id] {
             if count < 2 {
@@ -567,17 +572,19 @@ open class SwiftMessages {
         private var presenters = Set<Presenter>()
     }
 
+    @MainActor
     func show(presenter: Presenter) {
         enqueue(presenter: presenter)
     }
 
     fileprivate var queue: [Presenter] = []
+    @MainActor
     fileprivate var delays = Delays()
     fileprivate var counts: [String : Int] = [:]
     fileprivate var _current: Presenter? = nil {
         didSet {
             if oldValue != nil {
-                Task { [weak self] in
+                Task { @MainActor [weak self] in
                     try? await Task.sleep(seconds: self?.pauseBetweenMessages ?? 0)
                     self?.dequeueNext()
                 }
@@ -585,6 +592,7 @@ open class SwiftMessages {
         }
     }
 
+    @MainActor
     fileprivate func enqueue(presenter: Presenter) {
         if presenter.config.ignoreDuplicates {
             counts[presenter.id] = (counts[presenter.id] ?? 0) + 1
@@ -611,6 +619,7 @@ open class SwiftMessages {
         }
     }
     
+    @MainActor
     fileprivate func dequeueNext() {
         guard queue.count > 0 else { return }
         if let _current, !_current.isOrphaned { return }
@@ -637,6 +646,7 @@ open class SwiftMessages {
         }
     }
 
+    @MainActor
     fileprivate func internalHide(presenter: Presenter) {
         if presenter == _current {
             hideCurrent()
@@ -646,6 +656,7 @@ open class SwiftMessages {
         }
     }
  
+    @MainActor
     fileprivate func hideCurrent(animated: Bool = true) {
         guard let current = _current, !current.isHiding else { return }
         let action = { [weak self] in
@@ -665,6 +676,7 @@ open class SwiftMessages {
 
     fileprivate weak var autohideToken: Presenter?
 
+    @MainActor
     fileprivate func queueAutoHide() {
         guard let current = _current else { return }
         autohideToken = current
@@ -707,6 +719,7 @@ extension SwiftMessages {
      - Parameter id: The id of a message that adopts `Identifiable`.
      - Returns: The view with matching id if currently being shown or hidden.
     */
+    @MainActor
     public func current<T: UIView>(id: String) -> T? {
         _current?.id == id ? _current?.view as? T : nil
     }
@@ -717,6 +730,7 @@ extension SwiftMessages {
      - Parameter id: The id of a message that adopts `Identifiable`.
      - Returns: The view with matching id if currently queued to be shown.
      */
+    @MainActor
     public func queued<T: UIView>(id: String) -> T? {
         queue.first { $0.id == id }?.view as? T
     }
@@ -728,6 +742,7 @@ extension SwiftMessages {
      - Parameter id: The id of a message that adopts `Identifiable`.
      - Returns: The view with matching id if currently queued to be shown.
      */
+    @MainActor
     public func currentOrQueued<T: UIView>(id: String) -> T? {
         return current(id: id) ?? queued(id: id)
     }
@@ -739,10 +754,12 @@ extension SwiftMessages {
 
 extension SwiftMessages: PresenterDelegate {
 
+    @MainActor
     func hide(presenter: Presenter) {
         self.internalHide(presenter: presenter)
     }
 
+    @MainActor
     public func hide(animator: Animator) {
         guard let presenter = self.presenter(forAnimator: animator) else { return }
         self.internalHide(presenter: presenter)
@@ -752,6 +769,7 @@ extension SwiftMessages: PresenterDelegate {
         autohideToken = nil
     }
 
+    @MainActor
     public func panEnded(animator: Animator) {
         queueAutoHide()
     }
@@ -879,26 +897,32 @@ extension SwiftMessages {
         globalInstance.show(config: config, viewProvider: viewProvider)
     }
     
+    @MainActor
     public static func show(view: UIView) {
         globalInstance.show(view: view)
     }
 
+    @MainActor
     public static func show(config: Config, view: UIView) {
         globalInstance.show(config: config, view: view)
     }
 
+    @MainActor
     public static func hide(animated: Bool = true) {
         globalInstance.hide(animated: animated)
     }
     
+    @MainActor
     public static func hideAll() {
         globalInstance.hideAll()
     }
     
+    @MainActor
     public static func hide(id: String) {
         globalInstance.hide(id: id)
     }
 
+    @MainActor
     public static func hideCounted(id: String) {
         globalInstance.hideCounted(id: id)
     }
@@ -921,14 +945,17 @@ extension SwiftMessages {
         }
     }
 
+    @MainActor
     public static func current<T: UIView>(id: String) -> T? {
         return globalInstance.current(id: id)
     }
 
+    @MainActor
     public static func queued<T: UIView>(id: String) -> T? {
         return globalInstance.queued(id: id)
     }
 
+    @MainActor
     public static func currentOrQueued<T: UIView>(id: String) -> T? {
         return globalInstance.currentOrQueued(id: id)
     }


### PR DESCRIPTION
Hi there! We make use of [Resolver](https://github.com/hmlongco/Resolver) for our dependency injection & service locator framework, and our SwiftMessages implementation involves registering our own instance of `SwiftMessages` as one of those dependencies.

When updating to the [latest release](https://github.com/SwiftKickMobile/SwiftMessages/releases/tag/10.0.0) (version 10.0.0), we are being required to annotate our dependency registration code with `@MainActor` due to the changes introduced in [this commit](https://github.com/SwiftKickMobile/SwiftMessages/commit/633b6e593b5730daf9e682cd21f50764bd1e257c). This ultimately requires us to make this change at the entry point of Resolver (which is executed at app launch), meaning we will end up registering **all** of our dependencies on the main thread even though that may not be necessary.

As mentioned on [a separate issue in the Resolver repo](https://github.com/hmlongco/Resolver/issues/150#issuecomment-1099699579) - Even with MainActor annotations, there is no guarantee that the escaping closures will execute on the main thread, which could cause unexpected or inconsistent behavior. ([Additional info on this subject if you're interested](https://mobile.blog/2022/03/28/swift-why-is-my-mainactor-code-running-in-the-background/))

I totally understand the need for having SwiftMessages UI code get executed on the main thread, but I am less sure of the need to require it at the class-level as opposed to limiting it to the functions & properties that truly need to be on the main thread. 

---

With that background out of the way - this PR is for relocating the MainActor annotation from the class level down into each function and property that the compiler requires it on. My implementation is admittedly naive, as I simply removed it from the class declaration and played whack-a-mole with the compiler until it was satisfied, so please let me know if I am making any invalid assumptions or if this may end up regressing the threading behavior that you were trying to fix to begin with.