### PR TITLE
feat(TopBottomPresentable): Adds 'TopBottomPresentable' protocol, allow any Animator to be presented correctly by the `Presenter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 10.0.1
+
+## Features
+
+* Adds 'TopBottomPresentable' protocol to allow animators implementation to reuse 'top/bottom' integration in presentation
+
 ## 10.0.0
 
 ### Features

--- a/SwiftMessages.podspec
+++ b/SwiftMessages.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name             = 'SwiftMessages'
-    spec.version          = '10.0.0'
+    spec.version          = '10.0.1'
     spec.license          = { :type => 'MIT' }
     spec.homepage         = 'https://github.com/SwiftKickMobile/SwiftMessages'
     spec.authors          = { 'Timothy Moose' => 'tim@swiftkickmobile.com' }

--- a/SwiftMessages.xcodeproj/project.pbxproj
+++ b/SwiftMessages.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		0797E40E26EE12B400691606 /* WindowScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0797E40D26EE12B400691606 /* WindowScene.swift */; };
 		220655121FAF82B600F4E00F /* MarginAdjustable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220655111FAF82B600F4E00F /* MarginAdjustable+Extensions.swift */; };
 		220D386E2597AA5B00BB2B88 /* SwiftMessages.Config+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220D386D2597AA5B00BB2B88 /* SwiftMessages.Config+Extensions.swift */; };
+		224C3C902C28A2F900B50B18 /* TopBottomPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224C3C8F2C28A2F900B50B18 /* TopBottomPresentable.swift */; };
+		224C3C932C28BC4900B50B18 /* TopBottomAnimationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224C3C922C28BC4400B50B18 /* TopBottomAnimationStyle.swift */; };
 		224FB69921153B440081D4DE /* CALayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224FB69821153B440081D4DE /* CALayer+Extensions.swift */; };
 		225304622290C76E00A03ACF /* NSLayoutConstraint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225304612290C76E00A03ACF /* NSLayoutConstraint+Extensions.swift */; };
 		225304662293000C00A03ACF /* KeyboardTrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225304652293000C00A03ACF /* KeyboardTrackingView.swift */; };
@@ -103,6 +105,8 @@
 		0797E40D26EE12B400691606 /* WindowScene.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowScene.swift; sourceTree = "<group>"; };
 		220655111FAF82B600F4E00F /* MarginAdjustable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarginAdjustable+Extensions.swift"; sourceTree = "<group>"; };
 		220D386D2597AA5B00BB2B88 /* SwiftMessages.Config+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftMessages.Config+Extensions.swift"; sourceTree = "<group>"; };
+		224C3C8F2C28A2F900B50B18 /* TopBottomPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBottomPresentable.swift; sourceTree = "<group>"; };
+		224C3C922C28BC4400B50B18 /* TopBottomAnimationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBottomAnimationStyle.swift; sourceTree = "<group>"; };
 		224FB69821153B440081D4DE /* CALayer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+Extensions.swift"; sourceTree = "<group>"; };
 		225304612290C76E00A03ACF /* NSLayoutConstraint+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+Extensions.swift"; sourceTree = "<group>"; };
 		225304652293000C00A03ACF /* KeyboardTrackingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardTrackingView.swift; sourceTree = "<group>"; };
@@ -314,20 +318,22 @@
 		864495571D4F7C490056EB2A /* Base */ = {
 			isa = PBXGroup;
 			children = (
-				86589D461D64B6E40041676C /* BaseView.swift */,
-				86AAF82C1D580F410031EE32 /* Theme.swift */,
-				8644955C1D4FAF7C0056EB2A /* WindowViewController.swift */,
-				867BED201D622793005212E3 /* BackgroundViewable.swift */,
-				864495551D4F7C390056EB2A /* Identifiable.swift */,
-				86AAF81D1D5549680031EE32 /* MarginAdjustable.swift */,
 				22E307FE1E74C5B100E35893 /* AccessibleMessage.swift */,
-				22982C162B6030B000852311 /* HapticMessage.swift */,
-				86AAF82A1D580DD70031EE32 /* Error.swift */,
 				2298C2061EE480D000E2DDC1 /* Animator.swift */,
-				2298C2041EE47DC900E2DDC1 /* Weak.swift */,
+				867BED201D622793005212E3 /* BackgroundViewable.swift */,
+				86589D461D64B6E40041676C /* BaseView.swift */,
 				22F27950210CE25900273E7F /* CornerRoundingView.swift */,
+				86AAF82A1D580DD70031EE32 /* Error.swift */,
+				22982C162B6030B000852311 /* HapticMessage.swift */,
+				864495551D4F7C390056EB2A /* Identifiable.swift */,
 				225304652293000C00A03ACF /* KeyboardTrackingView.swift */,
+				86AAF81D1D5549680031EE32 /* MarginAdjustable.swift */,
+				86AAF82C1D580F410031EE32 /* Theme.swift */,
+				224C3C922C28BC4400B50B18 /* TopBottomAnimationStyle.swift */,
+				224C3C8F2C28A2F900B50B18 /* TopBottomPresentable.swift */,
+				2298C2041EE47DC900E2DDC1 /* Weak.swift */,
 				0797E40D26EE12B400691606 /* WindowScene.swift */,
+				8644955C1D4FAF7C0056EB2A /* WindowViewController.swift */,
 			);
 			name = Base;
 			sourceTree = "<group>";
@@ -568,6 +574,7 @@
 				228F7DDF2ACF703A006C9644 /* SwiftMessageModifier.swift in Sources */,
 				224FB69921153B440081D4DE /* CALayer+Extensions.swift in Sources */,
 				22E01F641E74EC8B00ACE19A /* MaskingView.swift in Sources */,
+				224C3C932C28BC4900B50B18 /* TopBottomAnimationStyle.swift in Sources */,
 				2298C2051EE47DC900E2DDC1 /* Weak.swift in Sources */,
 				228F7DE02ACF703A006C9644 /* MessageViewConvertible.swift in Sources */,
 				86BBA9001D5E040600FE8F16 /* PassthroughView.swift in Sources */,
@@ -578,6 +585,7 @@
 				22E307FF1E74C5B100E35893 /* AccessibleMessage.swift in Sources */,
 				220D386E2597AA5B00BB2B88 /* SwiftMessages.Config+Extensions.swift in Sources */,
 				2270044B1FAFA6DD0045DDC3 /* PhysicsAnimation.swift in Sources */,
+				224C3C902C28A2F900B50B18 /* TopBottomPresentable.swift in Sources */,
 				86BBA9041D5E040600FE8F16 /* NSBundle+Extensions.swift in Sources */,
 				86BBA8FD1D5E03F800FE8F16 /* SwiftMessages.swift in Sources */,
 				86BBA9021D5E040600FE8F16 /* WindowViewController.swift in Sources */,

--- a/SwiftMessages/Animator.swift
+++ b/SwiftMessages/Animator.swift
@@ -10,6 +10,7 @@ import UIKit
 
 public typealias AnimationCompletion = (_ completed: Bool) -> Void
 
+@MainActor
 public protocol AnimationDelegate: AnyObject {
     func hide(animator: Animator)
     func panStarted(animator: Animator)

--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@MainActor
 protocol PresenterDelegate: AnimationDelegate {
     func hide(presenter: Presenter)
 }

--- a/SwiftMessages/SwiftMessages.Config+Extensions.swift
+++ b/SwiftMessages/SwiftMessages.Config+Extensions.swift
@@ -17,7 +17,7 @@ extension SwiftMessages.Config {
         }
     }
 
-    @available (iOS 13.0, *)
+    @available(iOS 13.0, *)
     var windowScene: UIWindowScene? {
         switch presentationContext {
         case .windowScene(let scene, _): return scene as? UIWindowScene

--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@MainActor
 private let globalInstance = SwiftMessages()
 
 /**
@@ -774,6 +773,7 @@ extension SwiftMessages: PresenterDelegate {
         queueAutoHide()
     }
 
+    @MainActor
     private func presenter(forAnimator animator: Animator) -> Presenter? {
         if let current = _current, animator === current.animator {
             return current
@@ -885,11 +885,12 @@ extension SwiftMessages {
      a set of static APIs that wrap calls to this instance. For example, `SwiftMessages.show()`
      is equivalent to `SwiftMessages.sharedInstance.show()`.
      */
+    @MainActor
     public static var sharedInstance: SwiftMessages {
         return globalInstance
     }
-    
-    public static func show(viewProvider: @escaping ViewProvider) {
+
+    nonisolated public static func show(viewProvider: @escaping ViewProvider) {
         globalInstance.show(viewProvider: viewProvider)
     }
     

--- a/SwiftMessages/TopBottomAnimation.swift
+++ b/SwiftMessages/TopBottomAnimation.swift
@@ -8,16 +8,12 @@
 
 import UIKit
 
+@MainActor
 public class TopBottomAnimation: NSObject, Animator {
-
-    public enum Style {
-        case top
-        case bottom
-    }
 
     public weak var delegate: AnimationDelegate?
 
-    public let style: Style
+    public let style: TopBottomAnimationStyle
 
     public var showDuration: TimeInterval = 0.4
 
@@ -41,11 +37,11 @@ public class TopBottomAnimation: NSObject, Animator {
     weak var containerView: UIView?
     var context: AnimationContext?
 
-    public init(style: Style) {
+    public init(style: TopBottomAnimationStyle) {
         self.style = style
     }
 
-    init(style: Style, delegate: AnimationDelegate) {
+    init(style: TopBottomAnimationStyle, delegate: AnimationDelegate) {
         self.style = style
         self.delegate = delegate
     }

--- a/SwiftMessages/TopBottomAnimationStyle.swift
+++ b/SwiftMessages/TopBottomAnimationStyle.swift
@@ -1,0 +1,12 @@
+//
+//  TopBottomAnimationStyle.swift
+//  SwiftMessages
+//
+//  Created by Timothy Moose on 6/23/24.
+//  Copyright © 2024 SwiftKick Mobile. All rights reserved.
+//
+
+public enum TopBottomAnimationStyle {
+    case top
+    case bottom
+}

--- a/SwiftMessages/TopBottomPresentable.swift
+++ b/SwiftMessages/TopBottomPresentable.swift
@@ -1,0 +1,53 @@
+//
+//  File.swift
+//  
+//
+//  Created by Julien Di Marco on 23/04/2024.
+//
+
+import Foundation
+
+// MARK: - TopBottom Presentable Definition
+
+protocol TopBottomPresentable {
+
+    var topBottomStyle: TopBottomAnimation.Style? { get }
+
+}
+
+// MARK: - TopBottom Presentable Conformances
+
+extension TopBottomAnimation: TopBottomPresentable {
+
+    var topBottomStyle: Style? { return style }
+
+}
+
+extension PhysicsAnimation: TopBottomPresentable {
+
+    var topBottomStyle: TopBottomAnimation.Style? {
+        switch placement {
+        case .top: return .top
+        case .bottom: return .bottom
+        default: return nil
+        }
+    }
+
+}
+
+// MARK: - Presentation Style Convenience
+
+extension SwiftMessages.PresentationStyle {
+    /// A temporary workaround to allow custom presentation contexts using `TopBottomAnimation`
+    /// to display properly behind bars. THe long term solution is to refactor all of the
+    /// presentation context logic to work with safe area insets.
+    var topBottomStyle: TopBottomAnimation.Style? {
+        switch self {
+        case .top: return .top
+        case .bottom: return .bottom
+        case .custom(let animator as TopBottomPresentable): return animator.topBottomStyle
+        case .center: return nil
+        default: return nil
+        }
+    }
+}

--- a/SwiftMessages/TopBottomPresentable.swift
+++ b/SwiftMessages/TopBottomPresentable.swift
@@ -9,30 +9,25 @@ import Foundation
 
 // MARK: - TopBottom Presentable Definition
 
+@MainActor
 protocol TopBottomPresentable {
-
-    var topBottomStyle: TopBottomAnimation.Style? { get }
-
+    var topBottomStyle: TopBottomAnimationStyle? { get }
 }
 
 // MARK: - TopBottom Presentable Conformances
 
 extension TopBottomAnimation: TopBottomPresentable {
-
-    var topBottomStyle: Style? { return style }
-
+    var topBottomStyle: TopBottomAnimationStyle? { return style }
 }
 
 extension PhysicsAnimation: TopBottomPresentable {
-
-    var topBottomStyle: TopBottomAnimation.Style? {
+    var topBottomStyle: TopBottomAnimationStyle? {
         switch placement {
         case .top: return .top
         case .bottom: return .bottom
         default: return nil
         }
     }
-
 }
 
 // MARK: - Presentation Style Convenience
@@ -41,7 +36,8 @@ extension SwiftMessages.PresentationStyle {
     /// A temporary workaround to allow custom presentation contexts using `TopBottomAnimation`
     /// to display properly behind bars. THe long term solution is to refactor all of the
     /// presentation context logic to work with safe area insets.
-    var topBottomStyle: TopBottomAnimation.Style? {
+    @MainActor
+    var topBottomStyle: TopBottomAnimationStyle? {
         switch self {
         case .top: return .top
         case .bottom: return .bottom

--- a/SwiftMessages/UIViewController+Extensions.swift
+++ b/SwiftMessages/UIViewController+Extensions.swift
@@ -85,17 +85,3 @@ extension UIViewController {
         return true
     }
 }
-
-extension SwiftMessages.PresentationStyle {
-    /// A temporary workaround to allow custom presentation contexts using `TopBottomAnimation`
-    /// to display properly behind bars. THe long term solution is to refactor all of the
-    /// presentation context logic to work with safe area insets.
-    var topBottomStyle: TopBottomAnimation.Style? {
-        switch self {
-        case .top: return .top
-        case .bottom: return .bottom
-        case .custom(let animator): return (animator as? TopBottomAnimation)?.style
-        case .center: return nil
-        }
-    }
-}


### PR DESCRIPTION
The current implementation of `Presenter` check for a `topBottomStyle` using `TopBottomAnimation.Style` enum which allow during install to present the `Message` over or under `navigation-bar` and  `tab-bar`.

However the current implementation of the `topBottomStyle` computed property limit all customisation of behaviour and only allow presentation in `.top` or `.bottom` style with the `TopBottomAnimation` animator.

I've implemented a simple `TopBottomPresentable` protocol which return the `TopBottomAnimation.Style?` behaviour needed; thus we can add conformance of this protocol to our existing `TopBottomAnimation` and `PhysicsAnimation`.

This would allow customisation in any `Animator` in the futur by simple conforming to `TopBottomPresentable`.

Hope this is convenient for other people as well and can make it in, I'll be available if you need any change or need to drop the last commit (podspecs & version change for my own use atm)