### PR TITLE
ADD: Popup extension supports weight configuration, and the most impo…

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -16,6 +16,9 @@ protocol PresenterDelegate: AnimationDelegate {
 @MainActor
 class Presenter: NSObject {
 
+    // Priority weight Greater weight priority display (can be accurately controlled)
+    var priorityWeight: Int = 0
+    
     // MARK: - API
 
     init(config: SwiftMessages.Config, view: UIView, delegate: PresenterDelegate) {

--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -15,9 +15,6 @@ protocol PresenterDelegate: AnimationDelegate {
 
 @MainActor
 class Presenter: NSObject {
-
-    // Priority weight Greater weight priority display (can be accurately controlled)
-    var priorityWeight: Int = 0
     
     // MARK: - API
 

--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -412,6 +412,18 @@ open class SwiftMessages {
         enqueue(presenter: presenter)
     }
     
+    /// Display pop-up (support priority setting)
+    /// - Parameters:
+    /// -config: indicates the configuration
+    /// -view: indicates the view
+    /// -priorityweight: priorityWeight (larger weight - priority display)
+    @MainActor
+    open func show(config: Config, view: UIView, priorityWeight: Int = 0) {
+        let presenter = Presenter(config: config, view: view, delegate: self)
+        presenter.priorityWeight = priorityWeight
+        enqueue(presenter: presenter)
+    }
+    
     /**
      Adds the given view to the message queue to be displayed
      with default configuration options.
@@ -622,6 +634,10 @@ open class SwiftMessages {
     fileprivate func dequeueNext() {
         guard queue.count > 0 else { return }
         if let _current, !_current.isOrphaned { return }
+        //Weight priority sorting
+        queue = queue.sorted(by: { p1, p2 in
+            return p1.priorityWeight > p2.priorityWeight
+        })
         let current = queue.removeFirst()
         self._current = current
         // Set `autohideToken` before the animation starts in case
@@ -908,6 +924,11 @@ extension SwiftMessages {
         globalInstance.show(config: config, view: view)
     }
 
+    @MainActor
+    public static func show(config: Config, view: UIView, priorityWeight: Int = 0) {
+        globalInstance.show(config: config, view: view, priorityWeight: priorityWeight)
+    }
+    
     @MainActor
     public static func hide(animated: Bool = true) {
         globalInstance.hide(animated: animated)


### PR DESCRIPTION
## Pop-ups support weight setting, the larger the weight, the priority display, for accurate control of the order of pop-ups,

### Use case scenarios:
1. The first charging box (named A) pops up before the user check-in box (named B). A and B depend on different API service interface responses before they know whether to display.

After the weight configuration, as long as the priorityWeight of A is set to 1 and the priorityWeight of B is set to 0, the user does not need to care who joins the popup queue first. The queue will sort according to priorityWeight and then decide who will be displayed first