### PR TITLE
SwiftMessages.Config expands the popupPriority property to support the popup queue to accurately control the display order according to the weight

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -16,6 +16,9 @@ protocol PresenterDelegate: AnimationDelegate {
 @MainActor
 class Presenter: NSObject {
 
+    // Priority weight Greater weight priority display (can be accurately controlled)
+    var priorityWeight: Int = 0
+    
     // MARK: - API
 
     init(config: SwiftMessages.Config, view: UIView, delegate: PresenterDelegate) {

--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -15,9 +15,6 @@ protocol PresenterDelegate: AnimationDelegate {
 
 @MainActor
 class Presenter: NSObject {
-
-    // Priority weight Greater weight priority display (can be accurately controlled)
-    var priorityWeight: Int = 0
     
     // MARK: - API
 

--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -630,7 +630,21 @@ open class SwiftMessages {
         guard queue.count > 0 else { return }
         if let _current, !_current.isOrphaned { return }
         //Priority ordering
-        queue = queue.sorted(by: { $0.config.popupPriority > $1.config.popupPriority })
+        queue = queue.sorted{ itemLeft, itemRight in
+            // The priority is sorted first
+            if itemLeft.config.popupPriority != itemRight.config.popupPriority {
+                return itemLeft.config.popupPriority > itemRight.config.popupPriority
+            }
+            
+            // The same priority is sorted in queue order
+            if let leftIndex = queue.firstIndex(of: itemLeft),
+                let rightIndex = queue.firstIndex(of: itemRight) {
+                return leftIndex < rightIndex
+            }
+            
+            // Default
+            return true
+        }
         let current = queue.removeFirst()
         self._current = current
         // Set `autohideToken` before the animation starts in case

--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -412,6 +412,18 @@ open class SwiftMessages {
         enqueue(presenter: presenter)
     }
     
+    /// Display pop-up (support priority setting)
+    /// - Parameters:
+    /// -config: indicates the configuration
+    /// -view: indicates the view
+    /// -priorityweight: priorityWeight (larger weight - priority display)
+    @MainActor
+    open func show(config: Config, view: UIView, priorityWeight: Int = 0) {
+        let presenter = Presenter(config: config, view: view, delegate: self)
+        presenter.priorityWeight = priorityWeight
+        enqueue(presenter: presenter)
+    }
+    
     /**
      Adds the given view to the message queue to be displayed
      with default configuration options.
@@ -622,6 +634,10 @@ open class SwiftMessages {
     fileprivate func dequeueNext() {
         guard queue.count > 0 else { return }
         if let _current, !_current.isOrphaned { return }
+        //Weight priority sorting
+        queue = queue.sorted(by: { p1, p2 in
+            return p1.priorityWeight > p2.priorityWeight
+        })
         let current = queue.removeFirst()
         self._current = current
         // Set `autohideToken` before the animation starts in case
@@ -908,6 +924,11 @@ extension SwiftMessages {
         globalInstance.show(config: config, view: view)
     }
 
+    @MainActor
+    public static func show(config: Config, view: UIView, priorityWeight: Int = 0) {
+        globalInstance.show(config: config, view: view, priorityWeight: priorityWeight)
+    }
+    
     @MainActor
     public static func hide(animated: Bool = true) {
         globalInstance.hide(animated: animated)


### PR DESCRIPTION
## PR description

SwiftMessages.Config expands the popupPriority property to support the popup queue to accurately control the display order according to the weight

## Use case scenario

In many cases, pop-ups need to be accurately controlled in the display order due to different business importance.

For example, there are two pop-ups: the popup window for recharge guidance (named A) and the popup window for daily tasks of users (named B). Both A and B must rely on different service interfaces to know whether to display pop-ups. We hope that users will see A first.

After the extended configuration of popupPriority, the developer can set A's popupPriority to 1 and B's popupPriority to 0, and the developer doesn't care who joins the queue first. The queue will be sorted according to the developer and then it will be decided who will be shown first

## SwiftMessages.Config extend

```
...
/**
Use popupPriority to accurately control the popup display sequence
popupPriority is of type Int. The larger the value, the more important the popup is, and it is displayed firs
*/

public var popupPriority: Int = 0

```

## dequeueNext()

```
...
//Priority ordering
queue = queue.sorted(by: { $0.config.popupPriority > $1.config.popupPriority })

...
```

## Developer use

```
        var config = SwiftMessages.defaultConfig
        config.popupPriority = 10 // The larger the value, the higher the priority
        config.presentationContext = .window(windowLevel: UIWindow.Level.normal)
        config.presentationStyle = .center
        SwiftMessages.show(config: config, view: messageView)

```

