### PR TITLE
feat: add SwiftUI static APIs

### DIFF
--- a/SwiftMessages/SwiftMessages.swift
+++ b/SwiftMessages/SwiftMessages.swift
@@ -939,3 +939,24 @@ extension SwiftMessages {
         globalInstance.set(count: count, for: id)
     }
 }
+
+// MARK: - SwiftUI Static APIs
+
+import SwiftUI
+
+/// SwiftUI Static APIs
+@available(iOS 13.0, *)
+extension SwiftMessages {
+
+    @available(iOS 14.0, *)
+    public static func show<T: View>(id: String, view: T) {
+        let view = MessageHostingView(id: id, content: view)
+        globalInstance.show(view: view)
+    }
+
+    @available(iOS 14.0, *)
+    public static func show<T: View>(id: String, @ViewBuilder view: () -> T) {
+        let view = MessageHostingView(id: id, content: view())
+        globalInstance.show(view: view)
+    }
+}


### PR DESCRIPTION
Helper APIs to be more SwiftUI-style and easier to use. So now a message could be assembled as simple as this:

```
Button("Show message") {
    SwiftMessages.show(id: "MyMessage") {
        VStack(alignment: .leading) {
            Text("My Message Title").font(.headline)
            Text("This was so easy to build and show a message").font(.subheadline)
        }
        .multilineTextAlignment(.leading)
        .padding()
        .background(.yellow)
    }
}
```