### PR TITLE
Fix crash on iPadOS 18+ when presenting bottom SwiftMessage above UITabBarController

### DIFF
--- a/SwiftMessages/Presenter.swift
+++ b/SwiftMessages/Presenter.swift
@@ -339,7 +339,7 @@ class Presenter: NSObject {
         }
 
         func bottomLayoutConstraint(view: UIView, containerView: UIView, viewController: UIViewController?) -> NSLayoutConstraint {
-            if case .bottom = config.presentationStyle.topBottomStyle, let tab = viewController as? UITabBarController, tab.sm_isVisible(view: tab.tabBar) {
+            if case .bottom = config.presentationStyle.topBottomStyle, let tab = viewController as? UITabBarController, tab.sm_isVisible(view: tab.tabBar), tab.tabBar.superview != nil, !tab.tabBar.frame.isEmpty {
                 return NSLayoutConstraint(item: view, attribute: .bottom, relatedBy: .equal, toItem: tab.tabBar, attribute: .top, multiplier: 1.00, constant: 0.0)
             }
             return NSLayoutConstraint(item: view, attribute: .bottom, relatedBy: .equal, toItem: containerView, attribute: .bottom, multiplier: 1.00, constant: 0.0)


### PR DESCRIPTION
## Description

This PR fixes #567 

Due to changes made to `UITabBar` in iPadOS 18.0 and later, SwiftMessages crashes when attempting to present a message using `.bottom` presentation style in a `UITabBarController`. The crash occurs in the `bottomLayoutConstraint(view:containerView:viewController:)` function in `Presenter.swift`. Specifically, SwiftMessages tries to attach a constraint to the top of the tab bar, but on iPadOS 18+ the tab bar may no longer exist in the expected position in the view hierarchy, leading to an invalid constraint and a crash.

### Solution

This PR adds additional safety checks before anchoring a bottom-presented message to the tab bar:
- Ensures the tab bar is a subview of the view hierarchy (`superview != nil`)
- Ensures the tab bar has a valid, non-empty frame (`!frame.isEmpty`)

If these conditions are not met, the fallback is to anchor the message to the bottom of the container view, preventing the crash.

### Impact

- **Fixes**: Crash on iPadOS 18+ when showing bottom messages over a UITabBarController.
- **Behavior**: On affected iPadOS versions, if the tab bar is unavailable or not ready, the message will appear at the bottom of the container instead of above the tab bar.
- **Backwards Compatible**: No impact to other iOS versions or presentation styles.

### Testing

1. Open the Demo app on a device or simulator running iPadOS 18+ and select "Explore"
2. Set the configuration presentation style to "Bottom" and click "Show".
3. It should crash prior to this PR's code change, otherwise, it shows the SwiftMessage successfully.

### Demo 

#### iPadOS 17.5
https://github.com/user-attachments/assets/01e708a5-6582-4b38-8a85-a1f62976dea3

#### iPadOS 18.5
https://github.com/user-attachments/assets/43e5aea2-1420-4a71-80c6-fa3b2de1e9e1